### PR TITLE
Fix formatted json encode

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -19,51 +19,30 @@ func benchPayload() []byte {
 var preparedPayload = benchPayload()
 
 func marshalProtobuf() ([]byte, error) {
-	pushEncoder := NewProtobufPushEncoder()
 	pub := &Publication{
 		Data: preparedPayload,
 	}
-	data, err := pushEncoder.EncodePublication(pub)
-	if err != nil {
-		return nil, err
-	}
-	push := &Push{
-		Type:    Push_PUBLICATION,
-		Channel: "test",
-		Data:    data,
-	}
-	data, err = pushEncoder.Encode(push)
+	pushBytes, err := EncodePublicationPush(TypeProtobuf, "test", pub)
 	if err != nil {
 		return nil, err
 	}
 	r := &Reply{
-		Result: data,
+		Result: pushBytes,
 	}
 	encoder := NewProtobufReplyEncoder()
-	data, _ = encoder.Encode(r)
-	return data, nil
+	return encoder.Encode(r)
 }
 
 func marshalJSON() ([]byte, error) {
-	pushEncoder := NewJSONPushEncoder()
 	pub := &Publication{
 		Data: preparedPayload,
 	}
-	data, err := pushEncoder.EncodePublication(pub)
-	if err != nil {
-		return nil, err
-	}
-	push := &Push{
-		Type:    Push_PUBLICATION,
-		Channel: "test",
-		Data:    data,
-	}
-	data, err = pushEncoder.Encode(push)
+	pushBytes, err := EncodePublicationPush(TypeJSON, "test", pub)
 	if err != nil {
 		return nil, err
 	}
 	r := &Reply{
-		Result: data,
+		Result: pushBytes,
 	}
 	encoder := NewJSONReplyEncoder()
 	return encoder.Encode(r)

--- a/bench_test.go
+++ b/bench_test.go
@@ -14,7 +14,7 @@ func benchPayload() []byte {
 		p = append(p, 'i')
 	}
 	return []byte(`{
-""input":"` + string(p) + `
+"input":"` + string(p) + `
 "}`)
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -13,7 +13,9 @@ func benchPayload() []byte {
 	for i := 0; i < size; i++ {
 		p = append(p, 'i')
 	}
-	return []byte(`{"input": "` + string(p) + `"}`)
+	return []byte(`{
+""input":"` + string(p) + `
+"}`)
 }
 
 var preparedPayload = benchPayload()
@@ -52,7 +54,7 @@ func BenchmarkReplyProtobufMarshal(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := marshalProtobuf()
 		if err != nil {
-			b.Fail()
+			b.Fatal(err)
 		}
 	}
 	b.ReportAllocs()
@@ -64,7 +66,7 @@ func BenchmarkReplyProtobufMarshalParallel(b *testing.B) {
 		for pb.Next() {
 			_, err := marshalProtobuf()
 			if err != nil {
-				b.Fail()
+				b.Fatal(err)
 			}
 		}
 	})

--- a/bpool.go
+++ b/bpool.go
@@ -1,0 +1,81 @@
+package protocol
+
+import (
+	"io"
+	"math/bits"
+	"sync"
+)
+
+var (
+	// Verify ByteBuffer implements io.Writer.
+	_ io.Writer = &ByteBuffer{}
+)
+
+// ByteBuffer implements a simple byte buffer.
+type ByteBuffer struct {
+	// B is the underlying byte slice.
+	B []byte
+}
+
+// Reset resets bb.
+func (bb *ByteBuffer) Reset() {
+	bb.B = bb.B[:0]
+}
+
+// Write appends p to bb.
+func (bb *ByteBuffer) Write(p []byte) (int, error) {
+	bb.B = append(bb.B, p...)
+	return len(p), nil
+}
+
+// pools contain pools for byte slices of various capacities.
+var pools [19]sync.Pool
+
+// maxBufferLength is the maximum length of an element that can be added to the Pool.
+const maxBufferLength = 262144 // 2^18
+
+// Log of base two, round up (for v > 0).
+func nextLogBase2(v uint32) uint32 {
+	return uint32(bits.Len32(v - 1))
+}
+
+// Log of base two, round down (for v > 0)
+func prevLogBase2(num uint32) uint32 {
+	next := nextLogBase2(num)
+	if num == (1 << next) {
+		return next
+	}
+	return next - 1
+}
+
+// getByteBuffer returns byte buffer with the given capacity.
+func getByteBuffer(length int) *ByteBuffer {
+	if length == 0 {
+		return &ByteBuffer{
+			B: nil,
+		}
+	}
+	if length > maxBufferLength {
+		return &ByteBuffer{
+			B: make([]byte, 0, length),
+		}
+	}
+	idx := nextLogBase2(uint32(length))
+	if v := pools[idx].Get(); v != nil {
+		return v.(*ByteBuffer)
+	}
+	return &ByteBuffer{
+		B: make([]byte, 0, 1<<idx),
+	}
+}
+
+// putByteBuffer returns bb to the pool.
+func putByteBuffer(bb *ByteBuffer) {
+	capacity := cap(bb.B)
+	if capacity == 0 || capacity > maxBufferLength {
+		return // drop.
+	}
+	idx := prevLogBase2(uint32(capacity))
+	bb.Reset()
+	pools[idx].Put(bb)
+}

--- a/bpool_test.go
+++ b/bpool_test.go
@@ -1,0 +1,47 @@
+package protocol
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPutConcurrent(t *testing.T) {
+	const concurrency = 10
+	doneCh := make(chan struct{}, concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			for capacity := 0; capacity < 100; capacity++ {
+				bb := getByteBuffer(capacity)
+				if len(bb.B) > 0 {
+					panic(fmt.Errorf("len(bb.B) must be zero; got %d", len(bb.B)))
+				}
+				if capacity < 0 {
+					capacity = 0
+				}
+				bb.B = append(bb.B, make([]byte, capacity)...)
+				putByteBuffer(bb)
+			}
+			doneCh <- struct{}{}
+		}()
+	}
+	tc := time.After(10 * time.Second)
+	for i := 0; i < concurrency; i++ {
+		select {
+		case <-tc:
+			t.Fatalf("timeout")
+		case <-doneCh:
+		}
+	}
+}
+
+func TestGetCapacity(t *testing.T) {
+	for i := 1; i < 130; i++ {
+		idx := nextLogBase2(uint32(i))
+		b := getByteBuffer(i)
+		require.Equal(t, 1<<idx, cap(b.B))
+		putByteBuffer(b)
+	}
+}

--- a/encode.go
+++ b/encode.go
@@ -25,15 +25,15 @@ func isValidJSON(b []byte) error {
 // PushEncoder ...
 type PushEncoder interface {
 	Encode(*Push) ([]byte, error)
-	EncodeMessage(*Message) ([]byte, error)
-	EncodePublication(*Publication) ([]byte, error)
-	EncodeJoin(*Join) ([]byte, error)
-	EncodeLeave(*Leave) ([]byte, error)
-	EncodeUnsubscribe(*Unsubscribe) ([]byte, error)
-	EncodeSubscribe(*Subscribe) ([]byte, error)
-	EncodeConnect(*Connect) ([]byte, error)
-	EncodeDisconnect(*Disconnect) ([]byte, error)
-	EncodeRefresh(*Refresh) ([]byte, error)
+	EncodeMessage(*Message, ...[]byte) ([]byte, error)
+	EncodePublication(*Publication, ...[]byte) ([]byte, error)
+	EncodeJoin(*Join, ...[]byte) ([]byte, error)
+	EncodeLeave(*Leave, ...[]byte) ([]byte, error)
+	EncodeUnsubscribe(*Unsubscribe, ...[]byte) ([]byte, error)
+	EncodeSubscribe(*Subscribe, ...[]byte) ([]byte, error)
+	EncodeConnect(*Connect, ...[]byte) ([]byte, error)
+	EncodeDisconnect(*Disconnect, ...[]byte) ([]byte, error)
+	EncodeRefresh(*Refresh, ...[]byte) ([]byte, error)
 }
 
 var _ PushEncoder = (*JSONPushEncoder)(nil)
@@ -60,66 +60,66 @@ func (e *JSONPushEncoder) Encode(message *Push) ([]byte, error) {
 }
 
 // EncodePublication to bytes.
-func (e *JSONPushEncoder) EncodePublication(message *Publication) ([]byte, error) {
+func (e *JSONPushEncoder) EncodePublication(message *Publication, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // EncodeMessage to bytes.
-func (e *JSONPushEncoder) EncodeMessage(message *Message) ([]byte, error) {
+func (e *JSONPushEncoder) EncodeMessage(message *Message, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // EncodeJoin to bytes.
-func (e *JSONPushEncoder) EncodeJoin(message *Join) ([]byte, error) {
+func (e *JSONPushEncoder) EncodeJoin(message *Join, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // EncodeLeave to bytes.
-func (e *JSONPushEncoder) EncodeLeave(message *Leave) ([]byte, error) {
+func (e *JSONPushEncoder) EncodeLeave(message *Leave, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // EncodeUnsubscribe to bytes.
-func (e *JSONPushEncoder) EncodeUnsubscribe(message *Unsubscribe) ([]byte, error) {
+func (e *JSONPushEncoder) EncodeUnsubscribe(message *Unsubscribe, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // EncodeSubscribe to bytes.
-func (e *JSONPushEncoder) EncodeSubscribe(message *Subscribe) ([]byte, error) {
+func (e *JSONPushEncoder) EncodeSubscribe(message *Subscribe, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // EncodeConnect to bytes.
-func (e *JSONPushEncoder) EncodeConnect(message *Connect) ([]byte, error) {
+func (e *JSONPushEncoder) EncodeConnect(message *Connect, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // EncodeDisconnect to bytes.
-func (e *JSONPushEncoder) EncodeDisconnect(message *Disconnect) ([]byte, error) {
+func (e *JSONPushEncoder) EncodeDisconnect(message *Disconnect, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // EncodeRefresh to bytes.
-func (e *JSONPushEncoder) EncodeRefresh(message *Refresh) ([]byte, error) {
+func (e *JSONPushEncoder) EncodeRefresh(message *Refresh, reuse ...[]byte) ([]byte, error) {
 	jw := newWriter()
 	message.MarshalEasyJSON(jw)
-	return jw.BuildBytes()
+	return jw.BuildBytes(reuse...)
 }
 
 // ProtobufPushEncoder ...
@@ -137,47 +137,137 @@ func (e *ProtobufPushEncoder) Encode(message *Push) ([]byte, error) {
 }
 
 // EncodePublication to bytes.
-func (e *ProtobufPushEncoder) EncodePublication(message *Publication) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodePublication(message *Publication, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 
 // EncodeMessage to bytes.
-func (e *ProtobufPushEncoder) EncodeMessage(message *Message) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodeMessage(message *Message, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 
 // EncodeJoin to bytes.
-func (e *ProtobufPushEncoder) EncodeJoin(message *Join) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodeJoin(message *Join, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 
 // EncodeLeave to bytes.
-func (e *ProtobufPushEncoder) EncodeLeave(message *Leave) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodeLeave(message *Leave, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 
 // EncodeUnsubscribe to bytes.
-func (e *ProtobufPushEncoder) EncodeUnsubscribe(message *Unsubscribe) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodeUnsubscribe(message *Unsubscribe, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 
 // EncodeSubscribe to bytes.
-func (e *ProtobufPushEncoder) EncodeSubscribe(message *Subscribe) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodeSubscribe(message *Subscribe, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 
 // EncodeConnect to bytes.
-func (e *ProtobufPushEncoder) EncodeConnect(message *Connect) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodeConnect(message *Connect, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 
 // EncodeDisconnect to bytes.
-func (e *ProtobufPushEncoder) EncodeDisconnect(message *Disconnect) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodeDisconnect(message *Disconnect, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 
 // EncodeRefresh to bytes.
-func (e *ProtobufPushEncoder) EncodeRefresh(message *Refresh) ([]byte, error) {
+func (e *ProtobufPushEncoder) EncodeRefresh(message *Refresh, reuse ...[]byte) ([]byte, error) {
+	if len(reuse) == 1 {
+		size := message.SizeVT()
+		if cap(reuse[0]) >= size {
+			n, err := message.MarshalToSizedBufferVT(reuse[0][:size])
+			if err != nil {
+				return nil, err
+			}
+			return reuse[0][:n], nil
+		}
+	}
 	return message.MarshalVT()
 }
 

--- a/encode_helpers.go
+++ b/encode_helpers.go
@@ -84,7 +84,7 @@ func newRefreshPush(data Raw) *Push {
 // byte buffer won't be reused in JSON case (so need to take care of this to not loose
 // performance at some point). Would be nice to add additional size for messages like
 // Connect push which can have variable length Connect.Subs field.
-const MaxJSONPushFieldsSize = 32
+const MaxJSONPushFieldsSize = 64
 
 func EncodePublicationPush(protoType Type, channel string, message *Publication) ([]byte, error) {
 	if protoType == TypeJSON {

--- a/encode_helpers.go
+++ b/encode_helpers.go
@@ -1,0 +1,230 @@
+package protocol
+
+// Some helpers to effectively construct Push messages by reusing byte buffers – reduces byte slice copies.
+
+// newMessagePush returns initialized async push message.
+func newMessagePush(data Raw) *Push {
+	return &Push{
+		Type: Push_MESSAGE,
+		Data: data,
+	}
+}
+
+// newPublicationPush returns initialized async publication message.
+func newPublicationPush(ch string, data Raw) *Push {
+	return &Push{
+		Type:    Push_PUBLICATION,
+		Channel: ch,
+		Data:    data,
+	}
+}
+
+// newJoinPush returns initialized async join message.
+func newJoinPush(ch string, data Raw) *Push {
+	return &Push{
+		Type:    Push_JOIN,
+		Channel: ch,
+		Data:    data,
+	}
+}
+
+// newLeavePush returns initialized async leave message.
+func newLeavePush(ch string, data Raw) *Push {
+	return &Push{
+		Type:    Push_LEAVE,
+		Channel: ch,
+		Data:    data,
+	}
+}
+
+// newUnsubscribePush returns initialized async unsubscribe message.
+func newUnsubscribePush(ch string, data Raw) *Push {
+	return &Push{
+		Type:    Push_UNSUBSCRIBE,
+		Channel: ch,
+		Data:    data,
+	}
+}
+
+// newSubscribePush returns initialized async subscribe message.
+func newSubscribePush(ch string, data Raw) *Push {
+	return &Push{
+		Type:    Push_SUBSCRIBE,
+		Channel: ch,
+		Data:    data,
+	}
+}
+
+// newConnectPush returns initialized async connect message.
+func newConnectPush(data Raw) *Push {
+	return &Push{
+		Type: Push_CONNECT,
+		Data: data,
+	}
+}
+
+// newDisconnectPush returns initialized async disconnect message.
+func newDisconnectPush(data Raw) *Push {
+	return &Push{
+		Type: Push_DISCONNECT,
+		Data: data,
+	}
+}
+
+// newRefreshPush returns initialized async refresh message.
+func newRefreshPush(data Raw) *Push {
+	return &Push{
+		Type: Push_REFRESH,
+		Data: data,
+	}
+}
+
+// At the moment this is hardcoded to a value which is enough for all our messages.
+// If we will have a message with field names total size greater than this value then
+// byte buffer won't be reused in JSON case (so need to take care of this to not loose
+// performance at some point).
+const MaxFieldsSize = 30
+
+func EncodePublicationPush(protoType Type, channel string, message *Publication) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodePublication(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newPublicationPush(channel, data)
+	return pushEncoder.Encode(push)
+}
+
+func EncodeJoinPush(protoType Type, channel string, message *Join) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodeJoin(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newJoinPush(channel, data)
+	return pushEncoder.Encode(push)
+}
+
+func EncodeLeavePush(protoType Type, channel string, message *Leave) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodeLeave(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newLeavePush(channel, data)
+	return pushEncoder.Encode(push)
+}
+
+func EncodeMessagePush(protoType Type, message *Message) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodeMessage(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newMessagePush(data)
+	return pushEncoder.Encode(push)
+}
+
+func EncodeUnsubscribePush(protoType Type, channel string, message *Unsubscribe) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodeUnsubscribe(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newUnsubscribePush(channel, data)
+	return pushEncoder.Encode(push)
+}
+
+func EncodeSubscribePush(protoType Type, channel string, message *Subscribe) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodeSubscribe(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newSubscribePush(channel, data)
+	return pushEncoder.Encode(push)
+}
+
+func EncodeDisconnectPush(protoType Type, message *Disconnect) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodeDisconnect(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newDisconnectPush(data)
+	return pushEncoder.Encode(push)
+}
+
+func EncodeConnectPush(protoType Type, message *Connect) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodeConnect(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newConnectPush(data)
+	return pushEncoder.Encode(push)
+}
+
+func EncodeRefreshPush(protoType Type, message *Refresh) ([]byte, error) {
+	pushEncoder := GetPushEncoder(protoType)
+	size := message.SizeVT()
+	if protoType == TypeJSON {
+		size += MaxFieldsSize
+	}
+	reuse := getByteBuffer(size)
+	defer putByteBuffer(reuse)
+	data, err := pushEncoder.EncodeRefresh(message, reuse.B)
+	if err != nil {
+		return nil, err
+	}
+	push := newRefreshPush(data)
+	return pushEncoder.Encode(push)
+}

--- a/encode_helpers.go
+++ b/encode_helpers.go
@@ -86,11 +86,22 @@ func newRefreshPush(data Raw) *Push {
 const MaxFieldsSize = 30
 
 func EncodePublicationPush(protoType Type, channel string, message *Publication) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := jsonPushEncoder
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodePublication(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newPublicationPush(channel, data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodePublication(message, reuse.B)
@@ -102,11 +113,22 @@ func EncodePublicationPush(protoType Type, channel string, message *Publication)
 }
 
 func EncodeJoinPush(protoType Type, channel string, message *Join) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := GetPushEncoder(protoType)
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodeJoin(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newJoinPush(channel, data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodeJoin(message, reuse.B)
@@ -118,11 +140,22 @@ func EncodeJoinPush(protoType Type, channel string, message *Join) ([]byte, erro
 }
 
 func EncodeLeavePush(protoType Type, channel string, message *Leave) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := jsonPushEncoder
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodeLeave(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newLeavePush(channel, data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodeLeave(message, reuse.B)
@@ -134,11 +167,22 @@ func EncodeLeavePush(protoType Type, channel string, message *Leave) ([]byte, er
 }
 
 func EncodeMessagePush(protoType Type, message *Message) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := jsonPushEncoder
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodeMessage(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newMessagePush(data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodeMessage(message, reuse.B)
@@ -150,11 +194,22 @@ func EncodeMessagePush(protoType Type, message *Message) ([]byte, error) {
 }
 
 func EncodeUnsubscribePush(protoType Type, channel string, message *Unsubscribe) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := jsonPushEncoder
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodeUnsubscribe(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newUnsubscribePush(channel, data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodeUnsubscribe(message, reuse.B)
@@ -166,11 +221,22 @@ func EncodeUnsubscribePush(protoType Type, channel string, message *Unsubscribe)
 }
 
 func EncodeSubscribePush(protoType Type, channel string, message *Subscribe) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := jsonPushEncoder
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodeSubscribe(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newSubscribePush(channel, data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodeSubscribe(message, reuse.B)
@@ -182,11 +248,22 @@ func EncodeSubscribePush(protoType Type, channel string, message *Subscribe) ([]
 }
 
 func EncodeDisconnectPush(protoType Type, message *Disconnect) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := jsonPushEncoder
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodeDisconnect(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newDisconnectPush(data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodeDisconnect(message, reuse.B)
@@ -198,11 +275,22 @@ func EncodeDisconnectPush(protoType Type, message *Disconnect) ([]byte, error) {
 }
 
 func EncodeConnectPush(protoType Type, message *Connect) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := jsonPushEncoder
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodeConnect(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newConnectPush(data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodeConnect(message, reuse.B)
@@ -214,11 +302,22 @@ func EncodeConnectPush(protoType Type, message *Connect) ([]byte, error) {
 }
 
 func EncodeRefreshPush(protoType Type, message *Refresh) ([]byte, error) {
-	pushEncoder := GetPushEncoder(protoType)
-	size := message.SizeVT()
 	if protoType == TypeJSON {
-		size += MaxFieldsSize
+		// Use branching here instead of GetPushEncoder(protoType) since otherwise
+		// Go allocates more on heap (due to interface involved).
+		pushEncoder := jsonPushEncoder
+		size := message.SizeVT() + MaxFieldsSize
+		reuse := getByteBuffer(size)
+		defer putByteBuffer(reuse)
+		data, err := pushEncoder.EncodeRefresh(message, reuse.B)
+		if err != nil {
+			return nil, err
+		}
+		push := newRefreshPush(data)
+		return pushEncoder.Encode(push)
 	}
+	pushEncoder := protobufPushEncoder
+	size := message.SizeVT()
 	reuse := getByteBuffer(size)
 	defer putByteBuffer(reuse)
 	data, err := pushEncoder.EncodeRefresh(message, reuse.B)

--- a/encode_helpers.go
+++ b/encode_helpers.go
@@ -79,18 +79,19 @@ func newRefreshPush(data Raw) *Push {
 	}
 }
 
-// At the moment this is hardcoded to a value which is enough for all our messages.
-// If we will have a message with field names total size greater than this value then
+// At the moment this is hardcoded to a value which should be enough for most our messages
+// sent. If we will have a message with field names total size greater than this value then
 // byte buffer won't be reused in JSON case (so need to take care of this to not loose
-// performance at some point).
-const MaxFieldsSize = 30
+// performance at some point). Would be nice to add additional size for messages like
+// Connect push which can have variable length Connect.Subs field.
+const MaxJSONPushFieldsSize = 32
 
 func EncodePublicationPush(protoType Type, channel string, message *Publication) ([]byte, error) {
 	if protoType == TypeJSON {
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := jsonPushEncoder
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodePublication(message, reuse.B)
@@ -117,7 +118,7 @@ func EncodeJoinPush(protoType Type, channel string, message *Join) ([]byte, erro
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := GetPushEncoder(protoType)
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodeJoin(message, reuse.B)
@@ -144,7 +145,7 @@ func EncodeLeavePush(protoType Type, channel string, message *Leave) ([]byte, er
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := jsonPushEncoder
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodeLeave(message, reuse.B)
@@ -171,7 +172,7 @@ func EncodeMessagePush(protoType Type, message *Message) ([]byte, error) {
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := jsonPushEncoder
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodeMessage(message, reuse.B)
@@ -198,7 +199,7 @@ func EncodeUnsubscribePush(protoType Type, channel string, message *Unsubscribe)
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := jsonPushEncoder
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodeUnsubscribe(message, reuse.B)
@@ -225,7 +226,7 @@ func EncodeSubscribePush(protoType Type, channel string, message *Subscribe) ([]
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := jsonPushEncoder
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodeSubscribe(message, reuse.B)
@@ -252,7 +253,7 @@ func EncodeDisconnectPush(protoType Type, message *Disconnect) ([]byte, error) {
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := jsonPushEncoder
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodeDisconnect(message, reuse.B)
@@ -279,7 +280,7 @@ func EncodeConnectPush(protoType Type, message *Connect) ([]byte, error) {
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := jsonPushEncoder
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodeConnect(message, reuse.B)
@@ -306,7 +307,7 @@ func EncodeRefreshPush(protoType Type, message *Refresh) ([]byte, error) {
 		// Use branching here instead of GetPushEncoder(protoType) since otherwise
 		// Go allocates more on heap (due to interface involved).
 		pushEncoder := jsonPushEncoder
-		size := message.SizeVT() + MaxFieldsSize
+		size := message.SizeVT() + MaxJSONPushFieldsSize
 		reuse := getByteBuffer(size)
 		defer putByteBuffer(reuse)
 		data, err := pushEncoder.EncodeRefresh(message, reuse.B)

--- a/encode_helpers_test.go
+++ b/encode_helpers_test.go
@@ -1,0 +1,28 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushHelpers(t *testing.T) {
+	msg := newMessagePush(Raw("{}"))
+	require.NotNil(t, msg)
+	msg = newJoinPush("test", Raw("{}"))
+	require.NotNil(t, msg)
+	msg = newLeavePush("test", Raw("{}"))
+	require.NotNil(t, msg)
+	msg = newPublicationPush("test", Raw("{}"))
+	require.NotNil(t, msg)
+	msg = newSubscribePush("test", Raw("{}"))
+	require.NotNil(t, msg)
+	msg = newUnsubscribePush("test", Raw("{}"))
+	require.NotNil(t, msg)
+	msg = newConnectPush(Raw("{}"))
+	require.NotNil(t, msg)
+	msg = newDisconnectPush(Raw("{}"))
+	require.NotNil(t, msg)
+	msg = newRefreshPush(Raw("{}"))
+	require.NotNil(t, msg)
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -5,12 +5,14 @@ import (
 	"strings"
 	"testing"
 
+	fastJSON "github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncode(t *testing.T) {
+func TestEncodeEasyJson(t *testing.T) {
 	data := []byte(`{
-  "num": "1"
+  "num": "1\n"
+
 }
 `)
 	pushEncoder := NewJSONPushEncoder()
@@ -19,13 +21,13 @@ func TestEncode(t *testing.T) {
 	}
 	res, err := pushEncoder.EncodePublication(pub)
 	require.NoError(t, err)
-
 	require.Len(t, strings.Split(string(res), "\n"), 1)
 }
 
 func TestEncodeStd(t *testing.T) {
 	data := []byte(`{
-  "num": "1"
+  "num": "1\n"
+
 }
 `)
 	pub := &Publication{
@@ -34,6 +36,20 @@ func TestEncodeStd(t *testing.T) {
 
 	res, err := json.Marshal(pub)
 	require.NoError(t, err)
+	require.Len(t, strings.Split(string(res), "\n"), 1)
+}
 
+func TestEncodeFast(t *testing.T) {
+	data := []byte(`{
+  "num": "1\n"
+
+}
+`)
+	pub := &Publication{
+		Data: data,
+	}
+
+	res, err := fastJSON.Marshal(pub)
+	require.NoError(t, err)
 	require.Len(t, strings.Split(string(res), "\n"), 1)
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,0 +1,39 @@
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncode(t *testing.T) {
+	data := []byte(`{
+  "num": "1"
+}
+`)
+	pushEncoder := NewJSONPushEncoder()
+	pub := &Publication{
+		Data: data,
+	}
+	res, err := pushEncoder.EncodePublication(pub)
+	require.NoError(t, err)
+
+	require.Len(t, strings.Split(string(res), "\n"), 1)
+}
+
+func TestEncodeStd(t *testing.T) {
+	data := []byte(`{
+  "num": "1"
+}
+`)
+	pub := &Publication{
+		Data: data,
+	}
+
+	res, err := json.Marshal(pub)
+	require.NoError(t, err)
+
+	require.Len(t, strings.Split(string(res), "\n"), 1)
+}

--- a/encode_writer.go
+++ b/encode_writer.go
@@ -55,14 +55,14 @@ func (w *writer) RawString(s string) {
 
 // Raw appends raw binary data to the buffer or sets the error if it is given. Useful for
 // calling with results of MarshalJSON-like functions.
-func (w *writer) Raw(data []byte, err error) {
+func (w *writer) Raw(src []byte, err error) {
 	switch {
 	case w.Error != nil:
 		return
 	case err != nil:
 		w.Error = err
-	case len(data) > 0:
-		_, _ = w.Buffer.Write(data)
+	case len(src) > 0:
+		_, _ = w.Buffer.Write(src)
 	default:
 		w.RawString("null")
 	}


### PR DESCRIPTION
Currently Javascript client parser can't delimit one message from another if we send formatted JSON with new lines as we are not compacting JSON since recent update (i.e. using easyjson).

This pull request fixes this removing new lines in JSON if any. Also some helpers introduced to further reduce allocations in both Protobuf and JSON cases – we now reusing byte slices where it's safe to do, so we avoid extra byte slice copy and thus saving one allocation.

### Before

```
BenchmarkReplyProtobufMarshal-12              	 5600274	       214.7 ns/op	     864 B/op	       3 allocs/op
BenchmarkReplyProtobufMarshalParallel-12      	 7303191	       168.9 ns/op	     864 B/op	       3 allocs/op
BenchmarkReplyJSONMarshal-12                  	 2644131	       455.6 ns/op	     928 B/op	       3 allocs/op
BenchmarkReplyJSONMarshalParallel-12          	 4816104	       252.9 ns/op	     928 B/op	       3 allocs/op
```

### After, without new line

```
BenchmarkReplyProtobufMarshal-12              	 5865307	       199.0 ns/op	     576 B/op	       2 allocs/op
BenchmarkReplyProtobufMarshalParallel-12      	10106815	       121.4 ns/op	     576 B/op	       2 allocs/op
BenchmarkReplyJSONMarshal-12                  	 2558091	       465.9 ns/op	     640 B/op	       2 allocs/op
BenchmarkReplyJSONMarshalParallel-12          	 5936446	       216.2 ns/op	     641 B/op	       2 allocs/op
```

### After, with new line

```
BenchmarkReplyProtobufMarshal-12              	 5929026	       199.1 ns/op	     576 B/op	       2 allocs/op
BenchmarkReplyProtobufMarshalParallel-12      	10129752	       121.9 ns/op	     576 B/op	       2 allocs/op
BenchmarkReplyJSONMarshal-12                  	 2119388	       568.3 ns/op	     928 B/op	       3 allocs/op
BenchmarkReplyJSONMarshalParallel-12          	 4530106	       268.6 ns/op	     929 B/op	       3 allocs/op
```

So Protobuf is now faster regardless new lines - since it does not matter as we are using length-prefixed format. JSON encode is faster for already compact input and slightly slower (and +1 alloc) with input which contains new line.  
