### PR TITLE
Fix bufio: buffer full error while unmarshaling large messages

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/binary"
 	"fmt"
@@ -231,47 +230,54 @@ type CommandDecoder interface {
 
 // JSONCommandDecoder ...
 type JSONCommandDecoder struct {
-	reader    *bytes.Reader
-	bufReader *bufio.Reader
+	//reader     *bytes.Reader
+	//bufReader  *bufio.Reader
+	decoder    *json.Decoder
+	data       []byte
+	isMultiple bool
 }
 
 // NewJSONCommandDecoder ...
 func NewJSONCommandDecoder(data []byte) *JSONCommandDecoder {
-	reader := bytes.NewReader(data)
+	//reader := bytes.NewReader(data)
+	isMultiple := bytes.Contains(data, []byte("\n"))
+	var decoder *json.Decoder
+	if isMultiple {
+		decoder = json.NewDecoder(bytes.NewReader(data))
+	}
 	return &JSONCommandDecoder{
-		reader:    reader,
-		bufReader: bufio.NewReader(reader),
+		//reader:     reader,
+		//bufReader:  bufio.NewReaderSize(reader, len(data)),
+		data:       data,
+		decoder:    decoder,
+		isMultiple: bytes.Contains(data, []byte("\n")),
 	}
 }
 
 // Reset ...
 func (d *JSONCommandDecoder) Reset(data []byte) error {
-	d.reader.Reset(data)
-	d.bufReader.Reset(d.reader)
+	isMultiple := bytes.Contains(data, []byte("\n"))
+	var decoder *json.Decoder
+	if isMultiple {
+		decoder = json.NewDecoder(bytes.NewReader(data))
+	}
+	d.data = data
+	d.isMultiple = isMultiple
+	d.decoder = decoder
 	return nil
 }
 
 // Decode ...
 func (d *JSONCommandDecoder) Decode() (*Command, error) {
 	var c Command
-	line, err := d.bufReader.ReadSlice(byte('\n'))
-	if err != nil {
-		if err == io.EOF {
-			if len(line) == 0 {
-				return nil, io.EOF
-			}
-			_, err = json.Parse(line, &c, json.ZeroCopy)
-			if err != nil {
-				return nil, err
-			}
-			return &c, io.EOF
+	if !d.isMultiple {
+		_, err := json.Parse(d.data, &c, json.ZeroCopy)
+		if err != nil {
+			return nil, err
 		}
-		return nil, err
+		return &c, io.EOF
 	}
-	if len(line) == 0 {
-		return nil, io.EOF
-	}
-	_, err = json.Parse(line, &c, json.ZeroCopy)
+	err := d.decoder.Decode(&c)
 	return &c, err
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -31,7 +31,7 @@ func TestJSONCommandDecoder_Decode_Single(t *testing.T) {
 
 func TestJSONCommandDecoder_Decode_Large(t *testing.T) {
 	var s string
-	for i := 0; i < 120000; i++ {
+	for i := 0; i < 200000; i++ {
 		s += "1"
 	}
 	data := []byte(`{"id": 1, "x": "` + s + `"}`)
@@ -58,6 +58,30 @@ func TestJSONCommandDecoder_Decode_Large(t *testing.T) {
 func TestJSONCommandDecoder_Decode_Many(t *testing.T) {
 	data := []byte(`{"id": 1}
 {"id": 2}`)
+	decoder := GetCommandDecoder(TypeJSON, data)
+	var commands []*Command
+	for {
+		cmd, err := decoder.Decode()
+		if err != nil {
+			if err == io.EOF {
+				if cmd != nil {
+					commands = append(commands, cmd)
+				}
+				break
+			}
+			t.Fatal(err)
+		}
+		if cmd != nil {
+			commands = append(commands, cmd)
+		}
+	}
+	require.Len(t, commands, 2)
+}
+
+func TestJSONCommandDecoder_Decode_Many_ExtraNewLine(t *testing.T) {
+	data := []byte(`{"id": 1}
+{"id": 2}
+`)
 	decoder := GetCommandDecoder(TypeJSON, data)
 	var commands []*Command
 	for {

--- a/decode_test.go
+++ b/decode_test.go
@@ -29,6 +29,32 @@ func TestJSONCommandDecoder_Decode_Single(t *testing.T) {
 	require.Len(t, commands, 1)
 }
 
+func TestJSONCommandDecoder_Decode_Large(t *testing.T) {
+	var s string
+	for i := 0; i < 120000; i++ {
+		s += "1"
+	}
+	data := []byte(`{"id": 1, "x": "` + s + `"}`)
+	decoder := GetCommandDecoder(TypeJSON, data)
+	var commands []*Command
+	for {
+		cmd, err := decoder.Decode()
+		if err != nil {
+			if err == io.EOF {
+				if cmd != nil {
+					commands = append(commands, cmd)
+				}
+				break
+			}
+			t.Fatal(err)
+		}
+		if cmd != nil {
+			commands = append(commands, cmd)
+		}
+	}
+	require.Len(t, commands, 1)
+}
+
 func TestJSONCommandDecoder_Decode_Many(t *testing.T) {
 	data := []byte(`{"id": 1}
 {"id": 2}`)


### PR DESCRIPTION
Before:

```
BenchmarkReplyJSONUnmarshal-12            	 2456772	       487.5 ns/op	     232 B/op	       3 allocs/op
BenchmarkReplyJSONUnmarshalParallel-12    	10671240	       113.2 ns/op	     232 B/op	       3 allocs/op
```

After:

```
BenchmarkReplyJSONUnmarshal-12            	 2625344	       445.3 ns/op	     232 B/op	       3 allocs/op
BenchmarkReplyJSONUnmarshalParallel-12    	11780377	       102.6 ns/op	     232 B/op	       3 allocs/op
```

But for multiple messages we now fallback to decoder - thus performance will be slower. This should not be a very frequent case – but will try to address later. Currently fixing a bug and keeping performance the same (actually a bit faster) for most used scenario.