### PR TITLE
Refactor decoder, speedup encoder

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -422,3 +422,240 @@ func unmarshalJSON(b *testing.B, data []byte) *ConnectRequest {
 	}
 	return cmd.Connect
 }
+
+func buildJSONMultiFrame(b *testing.B, n int) []byte {
+	b.Helper()
+	encoder := NewJSONCommandEncoder()
+	var out []byte
+	for i := 0; i < n; i++ {
+		cmd := &Command{
+			Id: uint32(i + 1),
+			Publish: &PublishRequest{
+				Channel: "test",
+				Data:    preparedPayload,
+			},
+		}
+		data, err := encoder.Encode(cmd)
+		if err != nil {
+			b.Fatal(err)
+		}
+		out = append(out, data...)
+		if i < n-1 {
+			out = append(out, '\n')
+		}
+	}
+	return out
+}
+
+func buildProtobufMultiFrame(b *testing.B, n int) []byte {
+	b.Helper()
+	encoder := NewProtobufCommandEncoder()
+	var out []byte
+	for i := 0; i < n; i++ {
+		cmd := &Command{
+			Id: uint32(i + 1),
+			Publish: &PublishRequest{
+				Channel: "test",
+				Data:    preparedPayload,
+			},
+		}
+		data, err := encoder.Encode(cmd)
+		if err != nil {
+			b.Fatal(err)
+		}
+		out = append(out, data...)
+	}
+	return out
+}
+
+func benchDecodeJSONMulti(b *testing.B, n int) {
+	data := buildJSONMultiFrame(b, n)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		decoder := GetCommandDecoder(TypeJSON, data)
+		for {
+			cmd, err := decoder.Decode()
+			if cmd != nil {
+				benchConnectRequest = nil // sink
+				_ = cmd
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		PutCommandDecoder(TypeJSON, decoder)
+	}
+}
+
+func benchDecodeProtobufMulti(b *testing.B, n int) {
+	data := buildProtobufMultiFrame(b, n)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		decoder := GetCommandDecoder(TypeProtobuf, data)
+		for {
+			cmd, err := decoder.Decode()
+			if cmd != nil {
+				_ = cmd
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		PutCommandDecoder(TypeProtobuf, decoder)
+	}
+}
+
+func benchEncodeProtobufCommand(b *testing.B, n int) {
+	cmd := &Command{
+		Id: 1,
+		Publish: &PublishRequest{
+			Channel: "test",
+			Data:    preparedPayload,
+		},
+	}
+	enc := NewProtobufCommandEncoder()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < n; j++ {
+			d, err := enc.Encode(cmd)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchData = d
+		}
+	}
+}
+
+func benchEncodeJSONCommand(b *testing.B, n int) {
+	cmd := &Command{
+		Id: 1,
+		Publish: &PublishRequest{
+			Channel: "test",
+			Data:    preparedPayload,
+		},
+	}
+	enc := NewJSONCommandEncoder()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < n; j++ {
+			d, err := enc.Encode(cmd)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchData = d
+		}
+	}
+}
+
+func benchProtobufDataEncoder(b *testing.B, n int) {
+	frame := make([]byte, 280)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		enc := GetDataEncoder(TypeProtobuf)
+		for j := 0; j < n; j++ {
+			_ = enc.Encode(frame)
+		}
+		benchData = enc.Finish()
+		PutDataEncoder(TypeProtobuf, enc)
+	}
+}
+
+func benchJSONDataEncoder(b *testing.B, n int) {
+	frame := make([]byte, 280)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		enc := GetDataEncoder(TypeJSON)
+		for j := 0; j < n; j++ {
+			_ = enc.Encode(frame)
+		}
+		benchData = enc.Finish()
+		PutDataEncoder(TypeJSON, enc)
+	}
+}
+
+func BenchmarkReplyEncodeProtobufOnly(b *testing.B) {
+	r := &Reply{Push: &Push{Channel: "test", Pub: &Publication{Data: preparedPayload}}}
+	enc := NewProtobufReplyEncoder()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		d, err := enc.Encode(r)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchData = d
+	}
+}
+
+func BenchmarkReplyEncodeJSONOnly(b *testing.B) {
+	r := &Reply{Push: &Push{Channel: "test", Pub: &Publication{Data: preparedPayload}}}
+	enc := NewJSONReplyEncoder()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		d, err := enc.Encode(r)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchData = d
+	}
+}
+
+func BenchmarkPushEncodeProtobufOnly(b *testing.B) {
+	p := &Push{Channel: "test", Pub: &Publication{Data: preparedPayload}}
+	enc := NewProtobufPushEncoder()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		d, err := enc.Encode(p)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchData = d
+	}
+}
+
+func BenchmarkPushEncodeJSONOnly(b *testing.B) {
+	p := &Push{Channel: "test", Pub: &Publication{Data: preparedPayload}}
+	enc := NewJSONPushEncoder()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		d, err := enc.Encode(p)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchData = d
+	}
+}
+
+func BenchmarkEncodeProtobufCommand1(b *testing.B)  { benchEncodeProtobufCommand(b, 1) }
+func BenchmarkEncodeProtobufCommand64(b *testing.B) { benchEncodeProtobufCommand(b, 64) }
+func BenchmarkEncodeJSONCommand1(b *testing.B)      { benchEncodeJSONCommand(b, 1) }
+func BenchmarkEncodeJSONCommand64(b *testing.B)     { benchEncodeJSONCommand(b, 64) }
+func BenchmarkProtobufDataEncoder8(b *testing.B)    { benchProtobufDataEncoder(b, 8) }
+func BenchmarkProtobufDataEncoder64(b *testing.B)   { benchProtobufDataEncoder(b, 64) }
+func BenchmarkJSONDataEncoder8(b *testing.B)        { benchJSONDataEncoder(b, 8) }
+func BenchmarkJSONDataEncoder64(b *testing.B)       { benchJSONDataEncoder(b, 64) }
+
+func BenchmarkCommandJSONUnmarshalMulti1(b *testing.B)   { benchDecodeJSONMulti(b, 1) }
+func BenchmarkCommandJSONUnmarshalMulti8(b *testing.B)   { benchDecodeJSONMulti(b, 8) }
+func BenchmarkCommandJSONUnmarshalMulti64(b *testing.B)  { benchDecodeJSONMulti(b, 64) }
+func BenchmarkCommandJSONUnmarshalMulti256(b *testing.B) { benchDecodeJSONMulti(b, 256) }
+
+func BenchmarkCommandProtobufUnmarshalMulti1(b *testing.B)   { benchDecodeProtobufMulti(b, 1) }
+func BenchmarkCommandProtobufUnmarshalMulti8(b *testing.B)   { benchDecodeProtobufMulti(b, 8) }
+func BenchmarkCommandProtobufUnmarshalMulti64(b *testing.B)  { benchDecodeProtobufMulti(b, 64) }
+func BenchmarkCommandProtobufUnmarshalMulti256(b *testing.B) { benchDecodeProtobufMulti(b, 256) }

--- a/decode.go
+++ b/decode.go
@@ -44,83 +44,45 @@ type CommandDecoder interface {
 // read buffer they came from. Raw payload fields are copied and are not affected.
 // The Protobuf decoders copy everything, so this applies to JSON only.
 type JSONCommandDecoder struct {
-	data            []byte
-	messageCount    int
-	prevNewLine     int
-	numMessagesRead int
+	data   []byte
+	offset int
 }
 
 // NewJSONCommandDecoder creates a new JSONCommandDecoder for the given frame.
 func NewJSONCommandDecoder(data []byte) *JSONCommandDecoder {
-	// Protocol message must be separated by exactly one `\n`.
-	messageCount := bytes.Count(data, []byte("\n")) + 1
-	if len(data) == 0 || data[len(data)-1] == '\n' {
-		// Protocol message must have zero or one `\n` at the end.
-		messageCount--
-	}
-	return &JSONCommandDecoder{
-		data:            data,
-		messageCount:    messageCount,
-		prevNewLine:     0,
-		numMessagesRead: 0,
-	}
+	return &JSONCommandDecoder{data: data}
 }
 
 // Reset makes the decoder ready to decode commands from the given frame.
 func (d *JSONCommandDecoder) Reset(data []byte) error {
-	// We have a strict contract that protocol messages should be separated by at most one `\n`.
-	messageCount := bytes.Count(data, []byte("\n")) + 1
-	if len(data) == 0 || data[len(data)-1] == '\n' {
-		// We have a strict contract that protocol message should use at most one `\n` at the end.
-		messageCount--
-	}
 	d.data = data
-	d.messageCount = messageCount
-	d.prevNewLine = 0
-	d.numMessagesRead = 0
+	d.offset = 0
 	return nil
 }
 
 // Decode returns the next Command in the frame. The last Command is returned
 // together with io.EOF, see the CommandDecoder interface.
 func (d *JSONCommandDecoder) Decode() (*Command, error) {
-	if d.messageCount == 0 {
+	if d.offset >= len(d.data) {
 		return nil, io.ErrUnexpectedEOF
 	}
+	rest := d.data[d.offset:]
+	var msg []byte
+	if idx := bytes.IndexByte(rest, '\n'); idx >= 0 {
+		msg = rest[:idx]
+		d.offset += idx + 1
+	} else {
+		msg = rest
+		d.offset = len(d.data)
+	}
 	var c Command
-	if d.messageCount == 1 {
-		_, err := json.Parse(d.data, &c, json.ZeroCopy)
-		if err != nil {
-			return nil, err
-		}
+	if _, err := json.Parse(msg, &c, json.ZeroCopy); err != nil {
+		return nil, err
+	}
+	if d.offset >= len(d.data) {
 		return &c, io.EOF
 	}
-	var nextNewLine int
-	if d.numMessagesRead == d.messageCount-1 {
-		// Last message, no need to search for a new line.
-		nextNewLine = len(d.data[d.prevNewLine:])
-	} else if len(d.data) > d.prevNewLine {
-		nextNewLine = bytes.Index(d.data[d.prevNewLine:], []byte("\n"))
-		if nextNewLine < 0 {
-			return nil, io.ErrShortBuffer
-		}
-	} else {
-		return nil, io.ErrShortBuffer
-	}
-	if len(d.data) >= d.prevNewLine+nextNewLine {
-		_, err := json.Parse(d.data[d.prevNewLine:d.prevNewLine+nextNewLine], &c, json.ZeroCopy)
-		if err != nil {
-			return nil, err
-		}
-		d.numMessagesRead++
-		d.prevNewLine = d.prevNewLine + nextNewLine + 1
-		if d.numMessagesRead == d.messageCount {
-			return &c, io.EOF
-		}
-		return &c, nil
-	} else {
-		return nil, io.ErrShortBuffer
-	}
+	return &c, nil
 }
 
 // ProtobufCommandDecoder is a CommandDecoder for commands prefixed with their

--- a/decode.go
+++ b/decode.go
@@ -16,82 +16,44 @@ type CommandDecoder interface {
 
 // JSONCommandDecoder ...
 type JSONCommandDecoder struct {
-	data            []byte
-	messageCount    int
-	prevNewLine     int
-	numMessagesRead int
+	data   []byte
+	offset int
 }
 
 // NewJSONCommandDecoder ...
 func NewJSONCommandDecoder(data []byte) *JSONCommandDecoder {
-	// Protocol message must be separated by exactly one `\n`.
-	messageCount := bytes.Count(data, []byte("\n")) + 1
-	if len(data) == 0 || data[len(data)-1] == '\n' {
-		// Protocol message must have zero or one `\n` at the end.
-		messageCount--
-	}
-	return &JSONCommandDecoder{
-		data:            data,
-		messageCount:    messageCount,
-		prevNewLine:     0,
-		numMessagesRead: 0,
-	}
+	return &JSONCommandDecoder{data: data}
 }
 
 // Reset ...
 func (d *JSONCommandDecoder) Reset(data []byte) error {
-	// We have a strict contract that protocol messages should be separated by at most one `\n`.
-	messageCount := bytes.Count(data, []byte("\n")) + 1
-	if len(data) == 0 || data[len(data)-1] == '\n' {
-		// We have a strict contract that protocol message should use at most one `\n` at the end.
-		messageCount--
-	}
 	d.data = data
-	d.messageCount = messageCount
-	d.prevNewLine = 0
-	d.numMessagesRead = 0
+	d.offset = 0
 	return nil
 }
 
 // Decode ...
 func (d *JSONCommandDecoder) Decode() (*Command, error) {
-	if d.messageCount == 0 {
+	if d.offset >= len(d.data) {
 		return nil, io.ErrUnexpectedEOF
 	}
+	rest := d.data[d.offset:]
+	var msg []byte
+	if idx := bytes.IndexByte(rest, '\n'); idx >= 0 {
+		msg = rest[:idx]
+		d.offset += idx + 1
+	} else {
+		msg = rest
+		d.offset = len(d.data)
+	}
 	var c Command
-	if d.messageCount == 1 {
-		_, err := json.Parse(d.data, &c, json.ZeroCopy)
-		if err != nil {
-			return nil, err
-		}
+	if _, err := json.Parse(msg, &c, json.ZeroCopy); err != nil {
+		return nil, err
+	}
+	if d.offset >= len(d.data) {
 		return &c, io.EOF
 	}
-	var nextNewLine int
-	if d.numMessagesRead == d.messageCount-1 {
-		// Last message, no need to search for a new line.
-		nextNewLine = len(d.data[d.prevNewLine:])
-	} else if len(d.data) > d.prevNewLine {
-		nextNewLine = bytes.Index(d.data[d.prevNewLine:], []byte("\n"))
-		if nextNewLine < 0 {
-			return nil, io.ErrShortBuffer
-		}
-	} else {
-		return nil, io.ErrShortBuffer
-	}
-	if len(d.data) >= d.prevNewLine+nextNewLine {
-		_, err := json.Parse(d.data[d.prevNewLine:d.prevNewLine+nextNewLine], &c, json.ZeroCopy)
-		if err != nil {
-			return nil, err
-		}
-		d.numMessagesRead++
-		d.prevNewLine = d.prevNewLine + nextNewLine + 1
-		if d.numMessagesRead == d.messageCount {
-			return &c, io.EOF
-		}
-		return &c, nil
-	} else {
-		return nil, io.ErrShortBuffer
-	}
+	return &c, nil
 }
 
 // ProtobufCommandDecoder ...

--- a/encode.go
+++ b/encode.go
@@ -372,8 +372,8 @@ func NewProtobufDataEncoder() *ProtobufDataEncoder {
 
 // Encode ...
 func (e *ProtobufDataEncoder) Encode(data []byte) error {
-	bs := make([]byte, 8)
-	n := binary.PutUvarint(bs, uint64(len(data)))
+	var bs [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(bs[:], uint64(len(data)))
 	e.buffer.Write(bs[:n])
 	e.buffer.Write(data)
 	return nil
@@ -591,14 +591,13 @@ func NewProtobufCommandEncoder() *ProtobufCommandEncoder {
 
 // Encode ...
 func (e *ProtobufCommandEncoder) Encode(cmd *Command) ([]byte, error) {
-	commandBytes, err := cmd.MarshalVT()
-	if err != nil {
+	size := cmd.SizeVT()
+	var prefix [binary.MaxVarintLen64]byte
+	prefixLen := binary.PutUvarint(prefix[:], uint64(size))
+	out := make([]byte, prefixLen+size)
+	copy(out, prefix[:prefixLen])
+	if _, err := cmd.MarshalToSizedBufferVT(out[prefixLen:]); err != nil {
 		return nil, err
 	}
-	bs := make([]byte, 8)
-	n := binary.PutUvarint(bs, uint64(len(commandBytes)))
-	var buf bytes.Buffer
-	buf.Write(bs[:n])
-	buf.Write(commandBytes)
-	return buf.Bytes(), nil
+	return out, nil
 }

--- a/encode.go
+++ b/encode.go
@@ -403,8 +403,8 @@ func NewProtobufDataEncoder() *ProtobufDataEncoder {
 // Encode appends an already encoded message to the frame, prefixing it with its
 // length encoded as a varint.
 func (e *ProtobufDataEncoder) Encode(data []byte) error {
-	bs := make([]byte, 8)
-	n := binary.PutUvarint(bs, uint64(len(data)))
+	var bs [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(bs[:], uint64(len(data)))
 	e.buffer.Write(bs[:n])
 	e.buffer.Write(data)
 	return nil
@@ -634,14 +634,13 @@ func NewProtobufCommandEncoder() *ProtobufCommandEncoder {
 // Encode Command to bytes prefixed with the command length encoded as a varint,
 // so that encoded commands may be sent one after another in a single frame.
 func (e *ProtobufCommandEncoder) Encode(cmd *Command) ([]byte, error) {
-	commandBytes, err := cmd.MarshalVT()
-	if err != nil {
+	size := cmd.SizeVT()
+	var prefix [binary.MaxVarintLen64]byte
+	prefixLen := binary.PutUvarint(prefix[:], uint64(size))
+	out := make([]byte, prefixLen+size)
+	copy(out, prefix[:prefixLen])
+	if _, err := cmd.MarshalToSizedBufferVT(out[prefixLen:]); err != nil {
 		return nil, err
 	}
-	bs := make([]byte, 8)
-	n := binary.PutUvarint(bs, uint64(len(commandBytes)))
-	var buf bytes.Buffer
-	buf.Write(bs[:n])
-	buf.Write(commandBytes)
-	return buf.Bytes(), nil
+	return out, nil
 }


### PR DESCRIPTION
`ProtobufCommandEncoder.Encode` and the whole-frame `JSONCommandDecoder` allocated more than they needed to on the encode/decode path used by non-streaming (WebSocket-style) transports, where a full frame arrives as a single `[]byte`. This is a sibling change to #41, which optimized the *streaming* decoders (`JSONStreamCommandDecoder` / `ProtobufStreamCommandDecoder` in `decode_stream.go`, reading from an `io.Reader`); this PR targets the separate `CommandDecoder` / `ProtobufCommandEncoder` types in `decode.go` / `encode.go` that decode/encode a whole in-memory frame at once. No overlap between the two.

## Fewer allocations

**`ProtobufCommandEncoder.Encode` allocated twice per command.** It called `cmd.MarshalVT()`, which itself allocates an exactly-sized buffer via `SizeVT()` + `MarshalToSizedBufferVT()`, then copied that result into a growing `bytes.Buffer` alongside the length prefix. It now computes the size up front and marshals directly into one correctly-sized buffer, skipping the intermediate copy. This is the same `SizeVT`/`MarshalToSizedBufferVT` pattern `MarshalVT` already used internally (see `client_vtproto.pb.go:130-141`), just inlined to avoid the second buffer.

**`ProtobufDataEncoder.Encode` allocated a length-prefix scratch slice per call.** `make([]byte, 8)` is replaced with a stack-allocated `[binary.MaxVarintLen64]byte`.

**`JSONCommandDecoder.Decode` used a two-pass scheme.** `NewJSONCommandDecoder`/`Reset` pre-scanned the whole frame with `bytes.Count(data, "\n")` to compute a message count, then `Decode` re-scanned from the last position on every call. It's replaced with a single incremental scan that splits on `\n` as it goes, tracking only an `offset`. Same zero-copy behavior (`json.Parse` is still called with `json.ZeroCopy` into slices of the caller's buffer).

## Numbers

Apple M4, `-count=3`, batch of 64 commands per frame, benchmarked against unmodified master:

| Benchmark | Before | After | Delta |
|---|---|---|---|
| `BenchmarkEncodeProtobufCommand64` (time) | 5927-6084 ns/op | 2783-2804 ns/op | ~2.1x faster |
| `BenchmarkEncodeProtobufCommand64` (mem) | 40960 B/op | 18432 B/op | ~55% less |
| `BenchmarkCommandJSONUnmarshalMulti64` (time) | 11890-11976 ns/op | 11270-11355 ns/op | ~5% faster |
| `BenchmarkCommandJSONUnmarshalMulti64` (mem) | 34830 B/op, 192 allocs | 34830 B/op, 192 allocs | unchanged |
| `BenchmarkCommandProtobufUnmarshalMulti64` | 5739-5807 ns/op, 35087 B/op | unchanged | `ProtobufCommandDecoder` is untouched by this PR |

## Compatibility

`gorelease -base=<current master>` reports **no API differences at all** — no incompatible section, no compatible-additions section. Every changed method keeps its existing signature; nothing new is exported. (`gorelease -base=v0.21.1`, the last tag, suggests `v0.22.0` for this branch, but it suggests the identical `v0.22.0` for unmodified master too — that's just the tool's default minor-bump suggestion for this pre-1.0 module when there's no tagged release since #41, not something this PR introduces.)

## Safety

**Bounds.** The new `JSONCommandDecoder.offset` can never exceed `len(data)`: each step advances it by `idx+1` where `idx < len(rest) = len(data)-offset`, so `offset_new <= len(data)`. No slice can go out of range regardless of input.

**Behavioral equivalence, checked by differential testing rather than by eye.** I ran the actual pre-PR `JSONCommandDecoder` implementation side-by-side against this branch's version, decoding the same input through both and comparing every returned `Command`, error and EOF signal at each step:
- 22 hand-picked edge cases: double newlines mid-stream, CRLF, garbage before/after valid messages, empty input, a lone `{`, unicode payloads, 50-message batches, leading/trailing newlines — all identical.
- Fuzzed for 45s / **5.1M random byte-string inputs** against the real old implementation — zero divergences.
- Traced *why* they can't diverge: the old decoder's `io.ErrShortBuffer` "newline not found" branch was already dead code, since its precomputed `messageCount` (from `bytes.Count(data, "\n")`) guarantees every non-final message's newline search succeeds. The new code performs the same split incrementally instead of precomputing a count — it's a simplification, not a behavior change.

**Encoder correctness.** `ProtobufCommandEncoder`'s new output is exercised via round-trip in the existing `TestProtobufCommandDecoder_Decode_Many` / `TestProtobufCommandDecoder_Decode_ShortData` tests (encode via `ProtobufCommandEncoder`, decode via `ProtobufCommandDecoder`, assert contents) — both pass unchanged on this branch.

**Nil-safety and thread-safety unchanged.** `SizeVT()` and `MarshalToSizedBufferVT()` both guard `m == nil` the same way `MarshalVT()` did. No shared mutable state is introduced (the varint prefix is a stack-local array per call); the "not safe for concurrent use" contract on `JSONCommandDecoder`/`ProtobufCommandDecoder`/`ProtobufCommandEncoder` is unchanged.

## Test plan

- [x] Rebased cleanly onto current `master` (no conflicts)
- [x] `go test ./... -race -count=1` passes
- [x] `go vet ./...` unchanged at 129 pre-existing warnings from generated easyjson code (identical on master)
- [x] Ran `FuzzJSONDecodeSingle`, `FuzzJSONDecodeMultiple`, `FuzzProtobufDecode`, `FuzzProtobufReplyDecode`, `FuzzProtobufStreamDecode`, `FuzzJSONStreamDecode` for 15s each (~1.5-2M execs each) — no crashes
- [x] Differential fuzz of `JSONCommandDecoder` against the pre-PR implementation, 5.1M inputs — zero divergences (see Safety above)
- [x] Benchmarked against unmodified `master` head-to-head (numbers above)
