### PR TITLE
Require a positive message size limit for stream command decoders

### DIFF
--- a/decode_stream.go
+++ b/decode_stream.go
@@ -25,22 +25,27 @@ var (
 	streamProtobufCommandDecoderPool sync.Pool
 )
 
-// GetStreamCommandDecoder returns a StreamCommandDecoder for the given protocol
-// type which reads commands from reader with no limit on the message size. It's
-// a shortcut for GetStreamCommandDecoderLimited with a zero limit.
-func GetStreamCommandDecoder(protoType Type, reader io.Reader) StreamCommandDecoder {
-	return GetStreamCommandDecoderLimited(protoType, reader, 0)
-}
+// errNonPositiveMessageSizeLimit is the panic value used when a stream decoder
+// is constructed without a positive message size limit. The limit prefix of a
+// Protobuf stream frame is attacker-controlled and used as an allocation size, so
+// an unbounded decoder reading untrusted input is a memory-exhaustion hazard.
+// Requiring a positive limit at construction turns that misconfiguration into a
+// loud, immediate failure instead of a silent one. See GHSA-4r3x-2rwr-6w65.
+const errNonPositiveMessageSizeLimit = "protocol: stream command decoder requires a positive messageSizeLimit"
 
 // GetStreamCommandDecoderLimited returns a StreamCommandDecoder for the given
 // protocol type, taking it from a pool and resetting it to read commands from
 // reader. Return it with PutStreamCommandDecoder once the stream is processed.
 //
 // Commands larger than messageSizeLimit bytes are rejected with
-// ErrMessageTooLarge. A zero or negative limit means no limit, which is only
-// appropriate for trusted input. Any type other than TypeJSON is treated as
-// TypeProtobuf.
+// ErrMessageTooLarge. messageSizeLimit must be positive - a zero or negative
+// limit panics, since an unbounded decoder over untrusted input can be driven to
+// allocate arbitrary memory by a single frame. Any type other than TypeJSON is
+// treated as TypeProtobuf.
 func GetStreamCommandDecoderLimited(protoType Type, reader io.Reader, messageSizeLimit int64) StreamCommandDecoder {
+	if messageSizeLimit <= 0 {
+		panic(errNonPositiveMessageSizeLimit)
+	}
 	if protoType == TypeJSON {
 		e := streamJsonCommandDecoderPool.Get()
 		if e == nil {
@@ -60,8 +65,8 @@ func GetStreamCommandDecoderLimited(protoType Type, reader io.Reader, messageSiz
 }
 
 // PutStreamCommandDecoder returns a StreamCommandDecoder obtained with
-// GetStreamCommandDecoder or GetStreamCommandDecoderLimited to the pool. The
-// decoder must not be used after that.
+// GetStreamCommandDecoderLimited to the pool. The decoder must not be used after
+// that.
 func PutStreamCommandDecoder(protoType Type, e StreamCommandDecoder) {
 	e.Reset(nil, 0)
 	if protoType == TypeJSON {
@@ -77,8 +82,8 @@ func PutStreamCommandDecoder(protoType Type, e StreamCommandDecoder) {
 // individual command must be bounded.
 //
 // A StreamCommandDecoder is not safe for concurrent use. Use
-// GetStreamCommandDecoder and PutStreamCommandDecoder to take one from a pool
-// and return it back when done.
+// GetStreamCommandDecoderLimited and PutStreamCommandDecoder to take one from a
+// pool and return it back when done.
 type StreamCommandDecoder interface {
 	// Decode returns the next Command from the stream together with the number
 	// of bytes attributed to it, or an error. It returns io.EOF when the stream
@@ -86,7 +91,9 @@ type StreamCommandDecoder interface {
 	// message size limit.
 	Decode() (*Command, int, error)
 	// Reset makes the decoder read from the given reader, applying the given
-	// message size limit. A zero or negative limit means no limit.
+	// message size limit. It is used internally to reuse a pooled decoder;
+	// obtain a decoder via GetStreamCommandDecoderLimited, which enforces a
+	// positive limit, rather than resetting one with a non-positive limit.
 	Reset(reader io.Reader, messageSizeLimit int64)
 }
 
@@ -102,19 +109,15 @@ type JSONStreamCommandDecoder struct {
 	messageSizeLimit int64
 }
 
-// NewJSONStreamCommandDecoder creates a new JSONStreamCommandDecoder reading
-// from reader. A zero or negative messageSizeLimit means no limit.
+// NewJSONStreamCommandDecoder creates a new JSONStreamCommandDecoder reading from
+// reader. messageSizeLimit must be positive; a zero or negative value panics.
 func NewJSONStreamCommandDecoder(reader io.Reader, messageSizeLimit int64) *JSONStreamCommandDecoder {
-	var limitedReader *io.LimitedReader
-	var bufioReader *bufio.Reader
-	if messageSizeLimit > 0 {
-		limitedReader = &io.LimitedReader{R: reader, N: messageSizeLimit + 1}
-		bufioReader = bufio.NewReader(limitedReader)
-	} else {
-		bufioReader = bufio.NewReader(reader)
+	if messageSizeLimit <= 0 {
+		panic(errNonPositiveMessageSizeLimit)
 	}
+	limitedReader := &io.LimitedReader{R: reader, N: messageSizeLimit + 1}
 	return &JSONStreamCommandDecoder{
-		reader:           bufioReader,
+		reader:           bufio.NewReader(limitedReader),
 		limitedReader:    limitedReader,
 		messageSizeLimit: messageSizeLimit,
 	}
@@ -173,8 +176,14 @@ type ProtobufStreamCommandDecoder struct {
 }
 
 // NewProtobufStreamCommandDecoder creates a new ProtobufStreamCommandDecoder
-// reading from reader. A zero or negative messageSizeLimit means no limit.
+// reading from reader. messageSizeLimit must be positive; a zero or negative
+// value panics, since the varint length prefix is attacker-controlled and used as
+// an allocation size, so an unbounded decoder over untrusted input is a
+// memory-exhaustion hazard.
 func NewProtobufStreamCommandDecoder(reader io.Reader, messageSizeLimit int64) *ProtobufStreamCommandDecoder {
+	if messageSizeLimit <= 0 {
+		panic(errNonPositiveMessageSizeLimit)
+	}
 	return &ProtobufStreamCommandDecoder{reader: bufio.NewReader(reader), messageSizeLimit: messageSizeLimit}
 }
 

--- a/decode_stream_test.go
+++ b/decode_stream_test.go
@@ -97,7 +97,7 @@ func BenchmarkStreamingDecode_JSON(b *testing.B) {
 }
 
 func testDecodingFrame(tb testing.TB, frame []byte, protoType Type) {
-	dec := GetStreamCommandDecoder(protoType, bytes.NewReader(frame))
+	dec := GetStreamCommandDecoderLimited(protoType, bytes.NewReader(frame), 1<<20)
 	_, size, err := dec.Decode()
 	require.NoError(tb, err)
 	if protoType == TypeProtobuf {
@@ -134,8 +134,8 @@ func TestJSONStreamCommandDecoder(t *testing.T) {
 		messageSizeLimit int64
 	}{
 		{
-			name:             "no limit",
-			messageSizeLimit: 0,
+			name:             "generous limit",
+			messageSizeLimit: 1 << 20,
 		},
 		{
 			name:             "with limit",
@@ -180,7 +180,7 @@ func TestJSONStreamCommandDecoder_ReuseDifferentLimit(t *testing.T) {
 	_, _, err := decoder.Decode()
 	require.ErrorIs(t, err, ErrMessageTooLarge)
 	PutStreamCommandDecoder(TypeJSON, decoder)
-	decoder = GetStreamCommandDecoderLimited(TypeJSON, bytes.NewBufferString(data), 0)
+	decoder = GetStreamCommandDecoderLimited(TypeJSON, bytes.NewBufferString(data), 1<<20)
 	cmd, _, err := decoder.Decode()
 	require.NoError(t, err)
 	require.NotNil(t, cmd)
@@ -212,9 +212,9 @@ func TestProtobufStreamCommandDecoder_HostileLength(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// No message size limit configured - the hostile length must still
-			// be rejected rather than allocated or panicked on.
-			decoder := GetStreamCommandDecoder(TypeProtobuf, bytes.NewReader(uvarint(tt.msgLength)))
+			// The hostile length far exceeds the configured limit and must be
+			// rejected rather than allocated or panicked on.
+			decoder := GetStreamCommandDecoderLimited(TypeProtobuf, bytes.NewReader(uvarint(tt.msgLength)), 1<<20)
 			defer PutStreamCommandDecoder(TypeProtobuf, decoder)
 			require.NotPanics(t, func() {
 				cmd, n, err := decoder.Decode()
@@ -232,11 +232,32 @@ func TestProtobufStreamCommandDecoder_TruncatedBody(t *testing.T) {
 	b := make([]byte, binary.MaxVarintLen64)
 	prefix := b[:binary.PutUvarint(b, 1024)]
 
-	decoder := GetStreamCommandDecoder(TypeProtobuf, bytes.NewReader(append(prefix, 0x01, 0x02)))
+	decoder := GetStreamCommandDecoderLimited(TypeProtobuf, bytes.NewReader(append(prefix, 0x01, 0x02)), 1<<20)
 	defer PutStreamCommandDecoder(TypeProtobuf, decoder)
 	cmd, _, err := decoder.Decode()
 	require.Nil(t, cmd)
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+// The stream decoders must refuse to be constructed without a positive message
+// size limit: an unbounded decoder over untrusted input can be driven to allocate
+// arbitrary memory by a single frame, so the misconfiguration fails loudly rather
+// than silently. See GHSA-4r3x-2rwr-6w65.
+func TestStreamCommandDecoder_PanicsOnNonPositiveLimit(t *testing.T) {
+	for _, limit := range []int64{0, -1} {
+		require.Panics(t, func() {
+			GetStreamCommandDecoderLimited(TypeProtobuf, bytes.NewReader(nil), limit)
+		})
+		require.Panics(t, func() {
+			GetStreamCommandDecoderLimited(TypeJSON, bytes.NewReader(nil), limit)
+		})
+		require.Panics(t, func() {
+			NewProtobufStreamCommandDecoder(bytes.NewReader(nil), limit)
+		})
+		require.Panics(t, func() {
+			NewJSONStreamCommandDecoder(bytes.NewReader(nil), limit)
+		})
+	}
 }
 
 func TestGetByteBuffer_NonPositiveLength(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -39,7 +39,7 @@
 //
 // Implementations are chosen by protocol [Type], usually through the pooled
 // helpers – [GetCommandDecoder]/[PutCommandDecoder], [GetDataEncoder]/[PutDataEncoder],
-// [GetStreamCommandDecoder]/[PutStreamCommandDecoder] and [ReplyPool]. These
+// [GetStreamCommandDecoderLimited]/[PutStreamCommandDecoder] and [ReplyPool]. These
 // helpers reuse objects between messages and let a server avoid allocations on
 // hot paths.
 //

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -65,14 +65,15 @@ func FuzzProtobufReplyDecode(f *testing.F) {
 }
 
 // The stream decoders read a length prefix from an untrusted peer before the
-// message body, so they are the ones that must not allocate or panic on it.
-// Fuzzed with no size limit configured, which is the weakest configuration.
+// message body, so they are the ones that must not allocate or panic on it. A
+// positive size limit is always configured (the decoders require one); a declared
+// length above it must be rejected rather than allocated.
 func FuzzProtobufStreamDecode(f *testing.F) {
 	f.Add([]byte{0x00})
 	f.Add([]byte{0x02, 0x08, 0x01})
 	f.Add([]byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x40}) // Huge declared length.
 	f.Fuzz(func(t *testing.T, b []byte) {
-		decoder := GetStreamCommandDecoder(TypeProtobuf, bytes.NewReader(b))
+		decoder := GetStreamCommandDecoderLimited(TypeProtobuf, bytes.NewReader(b), 1<<20)
 		defer PutStreamCommandDecoder(TypeProtobuf, decoder)
 		// Each successful Decode consumes at least the length prefix byte.
 		for i := 0; i <= len(b); i++ {
@@ -88,7 +89,7 @@ func FuzzJSONStreamDecode(f *testing.F) {
 	f.Add([]byte(`{"id":1}` + "\n"))
 	f.Add([]byte(`{"id":1}` + "\n" + `{"id":2}` + "\n"))
 	f.Fuzz(func(t *testing.T, b []byte) {
-		decoder := GetStreamCommandDecoder(TypeJSON, bytes.NewReader(b))
+		decoder := GetStreamCommandDecoderLimited(TypeJSON, bytes.NewReader(b), 1<<20)
 		defer PutStreamCommandDecoder(TypeJSON, decoder)
 		for i := 0; i <= len(b); i++ {
 			if _, _, err := decoder.Decode(); err != nil {


### PR DESCRIPTION
## Summary

The protobuf stream command decoder reads a varint length prefix and allocates a buffer of that size **before** reading the body. With no limit configured (`messageSizeLimit == 0`, the previous "unbounded" mode), a peer could declare a huge length in a ~5-byte frame and force a proportional allocation — an unauthenticated memory-exhaustion DoS. This is the residual of [GHSA-4r3x-2rwr-6w65](https://github.com/centrifugal/centrifugo/security/advisories/GHSA-4r3x-2rwr-6w65) (the panic it describes was already fixed in v0.20.0; the uncapped *allocation* was not).

## Approach

Rather than making an unbounded decoder tolerate untrusted input, **make the limit mandatory**:

- `GetStreamCommandDecoderLimited`, `NewProtobufStreamCommandDecoder`, and `NewJSONStreamCommandDecoder` now **panic on a non-positive `messageSizeLimit`**.
- Removed the `GetStreamCommandDecoder` shortcut — it could only construct the unsafe unbounded decoder. Callers must now pass an explicit limit (a compile error where the shortcut was used, rather than a silent runtime hazard).

With a positive limit the decoder already rejects an oversized declared length *before* allocating (`msgLength > messageSizeLimit → ErrMessageTooLarge`), so the allocation is bounded by the operator's configured limit. The package gets simpler, not more complex.

### Why not a bounded/lazy allocation in the decoder?

An earlier revision of this PR grew the buffer incrementally so allocation tracked received bytes even at `limit == 0`. That tolerates the misconfiguration instead of fixing its root cause, adds complexity to security-sensitive parsing code, and doesn't enforce operator intent (an unbounded decoder would still process an arbitrarily large message). Requiring a limit is the cleaner contract: unsafe decoders simply can't be constructed, and the failure is loud.

## Caller impact

This is a **breaking change** for direct `protocol` consumers. Known call sites:
- **Centrifuge** — `HandleReadFrame` constructs the decoder; it will be updated to thread each transport's configured limit (WebSocket `MessageSizeLimit`; SSE/HTTP-stream/emulation `MaxRequestBodySize`), all of which are already coerced to positive defaults.
- **Centrifugo** — the WebTransport handler already passes a positive limit (coercing `0 → 64 KB`), so it is unaffected.

No exported signature of the retained functions changed.

## Tests

- `TestStreamCommandDecoder_PanicsOnNonPositiveLimit` — every construction path panics on `0` and negative limits.
- Existing stream tests updated to pass explicit positive limits.

`gofmt`/`go vet` clean; full suite and fuzzing pass.