### PR TITLE
Add DecodeTo to stream command decoders

### DIFF
--- a/decode_stream.go
+++ b/decode_stream.go
@@ -102,6 +102,41 @@ type StreamCommandDecoder interface {
 	Reset(reader io.Reader, messageSizeLimit int64)
 }
 
+// StreamCommandDecoderTo is implemented by StreamCommandDecoder implementations
+// which can decode into a Command owned by the caller, avoiding an allocation
+// per command. Both decoders returned by GetStreamCommandDecoderLimited
+// implement it, so a caller may type assert to it:
+//
+//	var cmd protocol.Command
+//	if d, ok := decoder.(protocol.StreamCommandDecoderTo); ok {
+//		size, err := d.DecodeTo(&cmd)
+//		// ...
+//	}
+//
+// It is deliberately a separate interface rather than a method on
+// StreamCommandDecoder, so that existing implementations keep compiling.
+type StreamCommandDecoderTo interface {
+	StreamCommandDecoder
+	// DecodeTo decodes the next Command from the stream into cmd, resetting it
+	// first, and returns the number of bytes attributed to the command. Errors
+	// are reported exactly as by Decode, including io.EOF together with the
+	// last command in the stream.
+	//
+	// The returned size says whether cmd was written to: a non-zero size means
+	// cmd holds a command which must be handled even when an error is returned
+	// alongside it, while a zero size means cmd was left untouched and still
+	// holds the previous command, so it must not be looked at. This mirrors the
+	// nil Command which Decode returns in that case.
+	//
+	// cmd is only owned by the decoder for the duration of the call, so it may
+	// be reused across calls. Reuse is only safe if nothing keeps the *Command
+	// past the next DecodeTo call. Fields reachable from it are freshly
+	// allocated on every call and may be retained: cmd is reset before
+	// decoding, so nothing is unmarshaled into a struct kept from a previous
+	// command.
+	DecodeTo(cmd *Command) (int, error)
+}
+
 // ErrMessageTooLarge is returned by a StreamCommandDecoder when a command in the
 // stream exceeds the configured message size limit.
 var ErrMessageTooLarge = errors.New("message size exceeds the limit")
@@ -134,31 +169,54 @@ func NewJSONStreamCommandDecoder(reader io.Reader, messageSizeLimit int64) *JSON
 // Decode returns the next Command from the stream, see the StreamCommandDecoder
 // interface.
 func (d *JSONStreamCommandDecoder) Decode() (*Command, int, error) {
+	cmdBytes, err := d.nextCommandBytes()
+	if len(cmdBytes) == 0 {
+		return nil, 0, err
+	}
+	// Allocated only once there is a command to decode, so that reaching the
+	// end of the stream costs nothing.
+	var c Command
+	if _, parseErr := json.Parse(cmdBytes, &c, 0); parseErr != nil {
+		return nil, 0, parseErr
+	}
+	return &c, len(cmdBytes), err
+}
+
+// DecodeTo decodes the next Command from the stream into cmd, see the
+// StreamCommandDecoderTo interface.
+func (d *JSONStreamCommandDecoder) DecodeTo(cmd *Command) (int, error) {
+	cmdBytes, err := d.nextCommandBytes()
+	if len(cmdBytes) == 0 {
+		return 0, err
+	}
+	cmd.Reset()
+	if _, parseErr := json.Parse(cmdBytes, cmd, 0); parseErr != nil {
+		return 0, parseErr
+	}
+	return len(cmdBytes), err
+}
+
+// nextCommandBytes returns the bytes of the next command in the stream. A nil
+// result means no command was read, in which case the error explains why. A
+// non-nil result may still come with io.EOF, which is how the last command in
+// the stream is reported.
+//
+// The returned slice is only valid until the next call, see readLine.
+func (d *JSONStreamCommandDecoder) nextCommandBytes() ([]byte, error) {
 	if d.messageSizeLimit > 0 {
 		d.limitedReader.N = int64(d.messageSizeLimit) + 1
 	}
 	cmdBytes, err := d.readLine()
 	if err != nil {
 		if d.messageSizeLimit > 0 && int64(len(cmdBytes)) > d.messageSizeLimit {
-			return nil, 0, ErrMessageTooLarge
+			return nil, ErrMessageTooLarge
 		}
 		if err == io.EOF && len(cmdBytes) > 0 {
-			var c Command
-			_, parseErr := json.Parse(cmdBytes, &c, 0)
-			if parseErr != nil {
-				return nil, 0, parseErr
-			}
-			return &c, len(cmdBytes), err
+			return cmdBytes, io.EOF
 		}
-		return nil, 0, err
+		return nil, err
 	}
-
-	var c Command
-	_, err = json.Parse(cmdBytes, &c, 0)
-	if err != nil {
-		return nil, 0, err
-	}
-	return &c, len(cmdBytes), nil
+	return cmdBytes, nil
 }
 
 // readLine returns the next `\n` terminated command, including the delimiter.
@@ -235,33 +293,63 @@ func NewProtobufStreamCommandDecoder(reader io.Reader, messageSizeLimit int64) *
 // interface. The size limit is checked against the length prefix before the
 // command is read, so an oversized command is rejected without buffering it.
 func (d *ProtobufStreamCommandDecoder) Decode() (*Command, int, error) {
-	msgLength, err := binary.ReadUvarint(d.reader)
+	msgLength, err := d.nextMessageLength()
 	if err != nil {
 		return nil, 0, err
 	}
+	// Allocated only once there is a command to decode, so that reaching the
+	// end of the stream costs nothing.
+	var c Command
+	if err = d.unmarshalMessage(&c, msgLength); err != nil {
+		return nil, 0, err
+	}
+	return &c, int(msgLength) + 8, nil
+}
 
+// DecodeTo decodes the next Command from the stream into cmd, see the
+// StreamCommandDecoderTo interface.
+func (d *ProtobufStreamCommandDecoder) DecodeTo(cmd *Command) (int, error) {
+	msgLength, err := d.nextMessageLength()
+	if err != nil {
+		return 0, err
+	}
+	cmd.Reset()
+	if err = d.unmarshalMessage(cmd, msgLength); err != nil {
+		return 0, err
+	}
+	return int(msgLength) + 8, nil
+}
+
+// nextMessageLength reads the length prefix of the next message and checks it
+// against the configured limit, before any of the message body is read.
+func (d *ProtobufStreamCommandDecoder) nextMessageLength() (uint64, error) {
+	msgLength, err := binary.ReadUvarint(d.reader)
+	if err != nil {
+		return 0, err
+	}
 	if d.messageSizeLimit > 0 && msgLength > uint64(d.messageSizeLimit) {
-		return nil, 0, ErrMessageTooLarge
+		return 0, ErrMessageTooLarge
 	}
 	// The length is declared by the other side and is used as an allocation size
 	// below, so it must be bounded even when no explicit limit is configured.
 	if msgLength > maxMessageLength {
-		return nil, 0, ErrMessageTooLarge
+		return 0, ErrMessageTooLarge
 	}
+	return msgLength, nil
+}
 
+// unmarshalMessage reads msgLength bytes and unmarshals them into cmd.
+func (d *ProtobufStreamCommandDecoder) unmarshalMessage(cmd *Command, msgLength uint64) error {
 	// Fast path: the whole message is already buffered, so it can be unmarshaled
 	// straight out of the bufio.Reader without copying it into a scratch buffer
 	// first. UnmarshalVT copies what it keeps, so the peeked slice may be
 	// invalidated by the Discard below.
 	if msgBytes, peekErr := d.reader.Peek(int(msgLength)); peekErr == nil {
-		var c Command
-		if err = c.UnmarshalVT(msgBytes); err != nil { // Note, UnmarshalVTUnsafe here will result into issues.
-			return nil, 0, err
+		if err := cmd.UnmarshalVT(msgBytes); err != nil { // Note, UnmarshalVTUnsafe here will result into issues.
+			return err
 		}
-		if _, err = d.reader.Discard(int(msgLength)); err != nil {
-			return nil, 0, err
-		}
-		return &c, int(msgLength) + 8, nil
+		_, err := d.reader.Discard(int(msgLength))
+		return err
 	}
 
 	bb := getByteBuffer(int(msgLength))
@@ -269,17 +357,12 @@ func (d *ProtobufStreamCommandDecoder) Decode() (*Command, int, error) {
 
 	n, err := io.ReadFull(d.reader, bb.B[:int(msgLength)])
 	if err != nil {
-		return nil, 0, err
+		return err
 	}
 	if uint64(n) != msgLength {
-		return nil, 0, io.ErrShortBuffer
+		return io.ErrShortBuffer
 	}
-	var c Command
-	err = c.UnmarshalVT(bb.B[:int(msgLength)]) // Note, UnmarshalVTUnsafe here will result into issues.
-	if err != nil {
-		return nil, 0, err
-	}
-	return &c, int(msgLength) + 8, nil
+	return cmd.UnmarshalVT(bb.B[:int(msgLength)]) // Note, UnmarshalVTUnsafe here will result into issues.
 }
 
 // Reset makes the decoder read from the given reader, applying the given message
@@ -288,3 +371,8 @@ func (d *ProtobufStreamCommandDecoder) Reset(reader io.Reader, messageSizeLimit 
 	d.messageSizeLimit = messageSizeLimit
 	d.reader.Reset(reader)
 }
+
+var (
+	_ StreamCommandDecoderTo = (*JSONStreamCommandDecoder)(nil)
+	_ StreamCommandDecoderTo = (*ProtobufStreamCommandDecoder)(nil)
+)

--- a/decode_stream_test.go
+++ b/decode_stream_test.go
@@ -373,3 +373,206 @@ func TestStreamingDecode_JSON_PoolReuse(t *testing.T) {
 		PutStreamCommandDecoder(TypeJSON, dec)
 	}
 }
+
+// decodeAllTo decodes a frame through DecodeTo, reusing a single Command, and
+// returns a description of every command it saw. Descriptions are built during
+// the loop, since cmd is overwritten by the next call.
+func decodeAllTo(tb testing.TB, protoType Type, frame []byte) []string {
+	tb.Helper()
+	dec := GetStreamCommandDecoderLimited(protoType, bytes.NewReader(frame), 1<<20)
+	defer PutStreamCommandDecoder(protoType, dec)
+	decTo, ok := dec.(StreamCommandDecoderTo)
+	require.True(tb, ok, "decoder must implement StreamCommandDecoderTo")
+
+	var cmd Command
+	var out []string
+	for {
+		size, err := decTo.DecodeTo(&cmd)
+		if size > 0 {
+			out = append(out, describeCommand(&cmd, size))
+		}
+		if err != nil {
+			require.ErrorIs(tb, err, io.EOF)
+			break
+		}
+	}
+	return out
+}
+
+// describeCommand renders the fields a reused Command could leak between calls.
+func describeCommand(cmd *Command, size int) string {
+	s := "id=" + strconv.Itoa(int(cmd.Id)) + " size=" + strconv.Itoa(size)
+	if cmd.Publish != nil {
+		s += " publish=" + cmd.Publish.Channel + ":" + string(cmd.Publish.Data)
+	}
+	if cmd.Subscribe != nil {
+		s += " subscribe=" + cmd.Subscribe.Channel
+	}
+	if cmd.Unsubscribe != nil {
+		s += " unsubscribe=" + cmd.Unsubscribe.Channel
+	}
+	if cmd.Ping != nil {
+		s += " ping"
+	}
+	return s
+}
+
+// decodeAll decodes a frame through Decode, for comparison with DecodeTo.
+func decodeAll(tb testing.TB, protoType Type, frame []byte) []string {
+	tb.Helper()
+	dec := GetStreamCommandDecoderLimited(protoType, bytes.NewReader(frame), 1<<20)
+	defer PutStreamCommandDecoder(protoType, dec)
+	var out []string
+	for {
+		cmd, size, err := dec.Decode()
+		if cmd != nil {
+			out = append(out, describeCommand(cmd, size))
+		}
+		if err != nil {
+			require.ErrorIs(tb, err, io.EOF)
+			break
+		}
+	}
+	return out
+}
+
+// mixedCommandFrame builds a frame whose commands set different fields, so a
+// Command reused without a reset would carry stale ones over.
+func mixedCommandFrame(tb testing.TB, protoType Type) []byte {
+	tb.Helper()
+	cmds := []*Command{
+		{Id: 1, Publish: &PublishRequest{Channel: "ch1", Data: Raw(`{"a":1}`)}},
+		{Id: 2, Subscribe: &SubscribeRequest{Channel: "ch2"}},
+		{Id: 3, Ping: &PingRequest{}},
+		{Id: 4, Unsubscribe: &UnsubscribeRequest{Channel: "ch4"}},
+		{Id: 5, Publish: &PublishRequest{Channel: "ch5", Data: Raw(`{"b":2}`)}},
+		// Long enough to spill past the bufio.Reader buffer.
+		{Id: 6, Publish: &PublishRequest{Channel: strings.Repeat("z", 9000), Data: Raw(`{}`)}},
+		{Id: 7, Ping: &PingRequest{}},
+	}
+	encoder := GetDataEncoder(protoType)
+	for _, cmd := range cmds {
+		var data []byte
+		var err error
+		if protoType == TypeProtobuf {
+			data, err = cmd.MarshalVT()
+		} else {
+			data, err = NewJSONCommandEncoder().Encode(cmd)
+		}
+		require.NoError(tb, err)
+		require.NoError(tb, encoder.Encode(data))
+	}
+	frame := encoder.Finish()
+	PutDataEncoder(protoType, encoder)
+	return frame
+}
+
+// DecodeTo must produce exactly what Decode produces, with no field of a
+// previous command surviving into the next one.
+func TestStreamingDecodeTo_MatchesDecode(t *testing.T) {
+	for _, protoType := range []Type{TypeJSON, TypeProtobuf} {
+		frame := mixedCommandFrame(t, protoType)
+		require.Equal(t, decodeAll(t, protoType, frame), decodeAllTo(t, protoType, frame))
+	}
+}
+
+// A Command reused across DecodeTo calls must not keep fields from a command
+// decoded earlier.
+func TestStreamingDecodeTo_NoStaleFields(t *testing.T) {
+	for _, protoType := range []Type{TypeJSON, TypeProtobuf} {
+		got := decodeAllTo(t, protoType, mixedCommandFrame(t, protoType))
+		require.Len(t, got, 7)
+		require.Equal(t, "id=2 subscribe=ch2", trimSize(got[1]), "Publish must not survive into the next command")
+		require.Equal(t, "id=3 ping", trimSize(got[2]))
+		require.Equal(t, "id=4 unsubscribe=ch4", trimSize(got[3]))
+		require.Equal(t, "id=7 ping", trimSize(got[6]))
+	}
+}
+
+// trimSize drops the size field, which differs between the two protocols.
+func trimSize(s string) string {
+	start := strings.Index(s, " size=")
+	end := strings.Index(s[start+1:], " ")
+	if end < 0 {
+		return s[:start]
+	}
+	return s[:start] + s[start+1+end:]
+}
+
+// DecodeTo must enforce the message size limit exactly as Decode does.
+func TestStreamingDecodeTo_MessageLimit(t *testing.T) {
+	for _, protoType := range []Type{TypeJSON, TypeProtobuf} {
+		frame := getTestFrame(t, protoType, 10000)
+		dec := GetStreamCommandDecoderLimited(protoType, bytes.NewReader(frame), 100)
+		var cmd Command
+		_, err := dec.(StreamCommandDecoderTo).DecodeTo(&cmd)
+		require.ErrorIs(t, err, ErrMessageTooLarge)
+		PutStreamCommandDecoder(protoType, dec)
+	}
+}
+
+// Data reachable from a Command decoded with DecodeTo must stay valid after
+// later DecodeTo calls, since a broker may keep a Publication built from it in
+// history for as long as it likes.
+func TestStreamingDecodeTo_RetainedPayloadsStayValid(t *testing.T) {
+	for _, protoType := range []Type{TypeJSON, TypeProtobuf} {
+		const numCommands = 12
+		encoder := GetDataEncoder(protoType)
+		for i := 0; i < numCommands; i++ {
+			// Sizes straddle the bufio.Reader buffer so both decode paths are used.
+			payload := `{"n":` + strconv.Itoa(i) + `,"pad":"` + strings.Repeat(string(rune('a'+i)), 400*i+1) + `"}`
+			cmd := &Command{
+				Id:      uint32(i + 1),
+				Publish: &PublishRequest{Channel: "ch" + strconv.Itoa(i), Data: Raw(payload)},
+			}
+			var data []byte
+			var err error
+			if protoType == TypeProtobuf {
+				data, err = cmd.MarshalVT()
+			} else {
+				data, err = NewJSONCommandEncoder().Encode(cmd)
+			}
+			require.NoError(t, err)
+			require.NoError(t, encoder.Encode(data))
+		}
+		frame := encoder.Finish()
+		PutDataEncoder(protoType, encoder)
+
+		dec := GetStreamCommandDecoderLimited(protoType, bytes.NewReader(frame), 1<<20).(StreamCommandDecoderTo)
+		// Retained the way a memory broker retains Publication data.
+		type retained struct {
+			channel string
+			data    Raw
+			req     *PublishRequest
+		}
+		var kept []retained
+		var cmd Command
+		for {
+			size, err := dec.DecodeTo(&cmd)
+			// A zero size means cmd was not written to and still holds the
+			// previous command, so it must not be looked at.
+			if size > 0 && cmd.Publish != nil {
+				kept = append(kept, retained{
+					channel: cmd.Publish.Channel,
+					data:    cmd.Publish.Data,
+					req:     cmd.Publish,
+				})
+			}
+			if err != nil {
+				require.ErrorIs(t, err, io.EOF)
+				break
+			}
+		}
+		PutStreamCommandDecoder(protoType, dec.(StreamCommandDecoder))
+
+		require.Len(t, kept, numCommands)
+		for i, k := range kept {
+			want := `{"n":` + strconv.Itoa(i) + `,"pad":"` + strings.Repeat(string(rune('a'+i)), 400*i+1) + `"}`
+			require.Equal(t, "ch"+strconv.Itoa(i), k.channel, "retained channel %d", i)
+			require.Equal(t, want, string(k.data), "retained data %d", i)
+			// The request struct itself must be a fresh one per command, not the
+			// one the next command was decoded into.
+			require.Equal(t, want, string(k.req.Data), "retained request %d", i)
+		}
+	}
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -3,6 +3,8 @@ package protocol
 import (
 	"bytes"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 )
 
 func FuzzJSONDecodeSingle(f *testing.F) {
@@ -93,6 +95,52 @@ func FuzzJSONStreamDecode(f *testing.F) {
 		defer PutStreamCommandDecoder(TypeJSON, decoder)
 		for i := 0; i <= len(b); i++ {
 			if _, _, err := decoder.Decode(); err != nil {
+				return
+			}
+		}
+		t.Fatal("decoder did not terminate")
+	})
+}
+
+// FuzzStreamDecodeTo checks that DecodeTo behaves exactly as Decode on the same
+// input: the same commands, the same sizes and the same errors.
+func FuzzStreamDecodeTo(f *testing.F) {
+	f.Add([]byte(`{"id":1}`+"\n"+`{"id":2,"publish":{"channel":"x"}}`+"\n"), true)
+	f.Add([]byte(`{"id":1,"subscribe":{"channel":"a"}}`+"\n"+`{"id":2,"ping":{}}`+"\n"), true)
+	f.Add([]byte{0x02, 0x08, 0x01}, false)
+	f.Add([]byte{0x00}, false)
+	f.Fuzz(func(t *testing.T, b []byte, useJSON bool) {
+		protoType := TypeProtobuf
+		if useJSON {
+			protoType = TypeJSON
+		}
+
+		decoder := GetStreamCommandDecoderLimited(protoType, bytes.NewReader(b), 1<<20)
+		defer PutStreamCommandDecoder(protoType, decoder)
+		decoderTo := GetStreamCommandDecoderLimited(protoType, bytes.NewReader(b), 1<<20)
+		defer PutStreamCommandDecoder(protoType, decoderTo)
+
+		var cmd Command
+		for i := 0; i <= len(b); i++ {
+			want, wantSize, wantErr := decoder.Decode()
+			gotSize, gotErr := decoderTo.(StreamCommandDecoderTo).DecodeTo(&cmd)
+
+			if (wantErr == nil) != (gotErr == nil) || (wantErr != nil && wantErr.Error() != gotErr.Error()) {
+				t.Fatalf("error mismatch: Decode=%v DecodeTo=%v", wantErr, gotErr)
+			}
+			if want == nil {
+				if gotSize != 0 {
+					t.Fatalf("Decode returned no command but DecodeTo reported size %d", gotSize)
+				}
+			} else {
+				if wantSize != gotSize {
+					t.Fatalf("size mismatch: Decode=%d DecodeTo=%d", wantSize, gotSize)
+				}
+				if !proto.Equal(want, &cmd) {
+					t.Fatalf("command mismatch: Decode=%v DecodeTo=%v", want, &cmd)
+				}
+			}
+			if wantErr != nil {
 				return
 			}
 		}


### PR DESCRIPTION
Stacked on #41 — review that one first, this PR targets its branch.

`Decode` allocates a `Command` per call. A caller which fully handles a command before asking for the next one can reuse a single `Command` instead.

## API

`DecodeTo` is deliberately **not** added to `StreamCommandDecoder`, since that would break existing implementations of the interface. It lives on a separate optional interface which both decoders implement:

```go
var cmd protocol.Command
if d, ok := decoder.(protocol.StreamCommandDecoderTo); ok {
    size, err := d.DecodeTo(&cmd)
    // size > 0 means cmd holds a command, even when err is non-nil (io.EOF
    // comes with the last command). size == 0 means cmd was left untouched
    // and still holds the previous one, mirroring the nil Command Decode
    // returns in that case.
}
```

## Numbers

| | `Decode` | `DecodeTo` | Δ |
|---|---|---|---|
| JSON, 1 cmd/frame | 200 ns, 344 B, 5 allocs | 176 ns, 200 B, 4 allocs | −12% time, −42% bytes |
| JSON, 8 cmds/frame | 1320 ns, 2417 B, 33 allocs | 1144 ns, 1264 B, 25 allocs | −13% / −48% |
| Protobuf, 1 cmd/frame | 120 ns, 344 B, 5 allocs | 99 ns, 200 B, 4 allocs | −18% / −42% |
| Protobuf, 8 cmds/frame | 694 ns, 2417 B, 33 allocs | 504 ns, 1264 B, 25 allocs | −27% / −48% |

## What is and isn't reused

Only the `Command` struct itself. `DecodeTo` resets it before decoding, so nothing is ever unmarshaled into a struct that was handed out with an earlier command — sub-requests, strings and `Raw` payloads are all freshly allocated on every call and may be retained indefinitely.

That property is load-bearing rather than incidental. In centrifuge, `handlePublish` takes `data := req.Data` without copying, and `MemoryBroker.Publish` stores that slice directly as `&Publication{Data: data}` in channel history, so a command's payload can outlive the connection. `TestStreamingDecodeTo_RetainedPayloadsStayValid` models exactly that: it retains channel, `Raw` payload and the `*PublishRequest` from twelve commands at sizes straddling the `bufio.Reader` buffer, keeps decoding, and checks all of them afterwards. The test is not vacuous — making the JSON path use `ZeroCopy` makes it fail in 4 places.

The reuse contract therefore only constrains the `*Command` pointer: it must not be kept past the next `DecodeTo` call.

## No regression to `Decode`

Refactoring the shared logic initially cost the `Decode` path ~16% on Protobuf, because the `Command` was being allocated before the end-of-stream check and every frame paid for one extra 144-byte allocation on its final call. `Decode` now allocates only once a command is known to exist. benchstat over 6 alternating runs against #41's branch: geomean +0.02%, allocation counts byte-identical.

## Testing

- `TestStreamingDecodeTo_MatchesDecode` — `DecodeTo` output is identical to `Decode` for both protocols over a frame of mixed command types.
- `TestStreamingDecodeTo_NoStaleFields` — a `Publish` followed by a `Subscribe` must not arrive with both set. Removing the `Reset` makes this fail in 6 places.
- `TestStreamingDecodeTo_RetainedPayloadsStayValid` — described above.
- `TestStreamingDecodeTo_MessageLimit` — `ErrMessageTooLarge` behaves as with `Decode`.
- `FuzzStreamDecodeTo` — differential fuzzing of the two entry points against each other on the same input, requiring identical commands (`proto.Equal`), sizes and errors. 5.3M execs, no failures.

Full suite passes, `-race` clean, `go vet` unchanged at 129 pre-existing warnings from generated easyjson code.

## Adoption

Nothing changes for existing callers. Centrifuge would opt in behind a flag, since it hands the `*Command` to `commandReadHandler` and `commandProcessedHandler` where third-party code could retain it. I checked centrifugo-pro's handlers separately — the throttler reads only string fields and the admin tracer marshals the command to JSON synchronously before anything goes async — so they hold nothing.
