### PR TITLE
Add test coverage for ByteBuffer.Write and prevLogBase2

### DIFF
--- a/bpool_test.go
+++ b/bpool_test.go
@@ -45,3 +45,27 @@ func TestGetCapacity(t *testing.T) {
 		putByteBuffer(b)
 	}
 }
+
+func TestByteBufferWrite(t *testing.T) {
+	var bb ByteBuffer
+	n, err := bb.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	n, err = bb.Write([]byte(" world"))
+	require.NoError(t, err)
+	require.Equal(t, 6, n)
+	require.Equal(t, "hello world", string(bb.B))
+	bb.Reset()
+	require.Equal(t, "", string(bb.B))
+}
+
+func TestPrevLogBase2(t *testing.T) {
+	// Exact powers of two: prevLogBase2 must equal the exponent itself.
+	require.Equal(t, uint32(0), prevLogBase2(1))
+	require.Equal(t, uint32(3), prevLogBase2(8))
+	require.Equal(t, uint32(4), prevLogBase2(16))
+	// Non-powers of two: prevLogBase2 must round down to the exponent below.
+	require.Equal(t, uint32(3), prevLogBase2(9))
+	require.Equal(t, uint32(3), prevLogBase2(15))
+	require.Equal(t, uint32(4), prevLogBase2(17))
+}


### PR DESCRIPTION
## What changed

Added two small unit tests in `bpool_test.go`:

- `TestByteBufferWrite`: exercises `ByteBuffer.Write` (an exported method that satisfies `io.Writer`, but had no direct test — only exercised indirectly through `append` calls elsewhere in the codebase).
- `TestPrevLogBase2`: exercises the non-power-of-two branch of `prevLogBase2`. In normal operation `putByteBuffer` always calls it with a capacity that came from `getByteBuffer` (always a power of two), so that branch was previously dead in test coverage.

## Why

Coverage check (`go tool cover -func`) showed `bpool.go`'s `Write` method at 0% and `prevLogBase2` at 75%, the only gaps in an otherwise well-tested file. No behavior changes — test-only.

## Verification

- `go build ./...` — passes
- `go vet ./...` — no new warnings (pre-existing copylocks warnings in generated `client.pb_easyjson.go` are unrelated)
- `go test ./...` — passes, including the new tests