### PR TITLE
Add test coverage for Raw JSON marshal/unmarshal edge cases

### DIFF
--- a/raw_test.go
+++ b/raw_test.go
@@ -33,3 +33,45 @@ func TestRaw(t *testing.T) {
 		t.Fatalf("no match: %v", err)
 	}
 }
+
+func TestRaw_MarshalJSON_Nil(t *testing.T) {
+	var r Raw
+	data, err := r.MarshalJSON()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if string(data) != "null" {
+		t.Fatalf("expected null, got %s", data)
+	}
+}
+
+func TestRaw_MarshalJSON_StripsNewlines(t *testing.T) {
+	r := Raw("{\n  \"key\": \"value\"\n}")
+	data, err := r.MarshalJSON()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if string(data) != `{  "key": "value"}` {
+		t.Fatalf("unexpected result: %s", data)
+	}
+}
+
+func TestRaw_UnmarshalJSON_NilPointer(t *testing.T) {
+	var r *Raw
+	err := r.UnmarshalJSON([]byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error on nil pointer")
+	}
+}
+
+func TestRaw_UnmarshalJSON_CopiesData(t *testing.T) {
+	var r Raw
+	data := []byte(`{"key": "value"}`)
+	if err := r.UnmarshalJSON(data); err != nil {
+		t.Fatalf("%v", err)
+	}
+	data[0] = 'X'
+	if r[0] == 'X' {
+		t.Fatal("Raw should hold a copy, not alias the input slice")
+	}
+}


### PR DESCRIPTION
## Summary
- `raw.go`'s doc comments call out specific behaviors (nil Raw marshals to `null`, embedded newlines are stripped, UnmarshalJSON on a nil pointer errors, UnmarshalJSON copies rather than aliases the input) that were undocumented by tests — only the happy-path round-trip against `encoding/json` was covered.
- Added four focused unit tests exercising each of these branches directly.

## Test plan
- New tests added to `raw_test.go`:
  - `TestRaw_MarshalJSON_Nil`: nil `Raw` marshals to `null`.
  - `TestRaw_MarshalJSON_StripsNewlines`: embedded `\n` bytes are stripped from the output.
  - `TestRaw_UnmarshalJSON_NilPointer`: calling `UnmarshalJSON` on a nil `*Raw` returns an error instead of panicking.
  - `TestRaw_UnmarshalJSON_CopiesData`: mutating the input slice after `UnmarshalJSON` does not affect the stored `Raw` value (guards against an aliasing regression).
- Verified with `go build ./...` and `go test ./...` — full suite passes.