### PR TITLE
Fix Decompress truncation when maxSize is math.MaxInt

### DIFF
--- a/framecodec.go
+++ b/framecodec.go
@@ -5,6 +5,7 @@ import (
 	"compress/flate"
 	"errors"
 	"io"
+	"math"
 	"sync"
 )
 
@@ -158,7 +159,7 @@ func (c *DeflateFrameCodec) Decompress(dst, frame []byte, maxSize int) ([]byte, 
 	if maxSize > 0 {
 		// Read one byte past the limit so an oversized frame is detected rather
 		// than silently truncated.
-		rd = io.LimitReader(r, int64(maxSize)+1)
+		rd = io.LimitReader(r, decompressBudget(maxSize))
 	}
 	out := bytes.NewBuffer(dst)
 	n, err := out.ReadFrom(rd)
@@ -169,6 +170,19 @@ func (c *DeflateFrameCodec) Decompress(dst, frame []byte, maxSize int) ([]byte, 
 		return nil, ErrFrameTooLarge
 	}
 	return out.Bytes(), nil
+}
+
+// decompressBudget is how many bytes Decompress may read while decoding one
+// frame: one more than maxSize, so that a frame which is over it is detected
+// rather than silently truncated. maxSize equal to math.MaxInt would overflow
+// int64(maxSize)+1, leaving a negative budget that stops the reader before it
+// delivers anything - the same hazard readBudget guards against for stream
+// decoders - so it is clamped.
+func decompressBudget(maxSize int) int64 {
+	if maxSize == math.MaxInt {
+		return math.MaxInt64
+	}
+	return int64(maxSize) + 1
 }
 
 // DeflateDictionary compresses dictionary content with raw DEFLATE and no preset

--- a/framecodec_test.go
+++ b/framecodec_test.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"testing"
 )
 
@@ -68,6 +69,21 @@ func TestFrameCodecDecompressErrors(t *testing.T) {
 	}
 	if _, err := c.Decompress(nil, []byte{0xff, 0x01, 0x02}, 0); err != ErrUnknownFrameCodec {
 		t.Fatalf("expected ErrUnknownFrameCodec for unknown marker, got %v", err)
+	}
+}
+
+// TestFrameCodecDecompressMaxSizeOverflow guards against int64(maxSize)+1
+// overflowing when maxSize is math.MaxInt: that used to turn into a negative
+// io.LimitReader budget, which made Decompress return an empty result with no
+// error instead of the decompressed frame.
+func TestFrameCodecDecompressMaxSizeOverflow(t *testing.T) {
+	dict := []byte("some dictionary content used for compression testing 1234567890")
+	c := NewDeflateFrameCodec("v1", dict)
+	msg := []byte("hello world hello world hello world hello world")
+	fr := c.Compress(nil, msg)
+	out, err := c.Decompress(nil, fr, math.MaxInt)
+	if err != nil || !bytes.Equal(out, msg) {
+		t.Fatalf("round trip with maxSize=math.MaxInt failed: err=%v out=%q", err, out)
 	}
 }
 


### PR DESCRIPTION
## Summary
`DeflateFrameCodec.Decompress` bounds the decompressed output with
`io.LimitReader(r, int64(maxSize)+1)`. When a caller passes
`maxSize == math.MaxInt` (a natural way to say "no real bound"), that
addition overflows to a negative `int64`, and `io.LimitReader` with a
non-positive `N` returns `io.EOF` on the very first read. `Decompress`
then reports success with an empty (or short) result instead of the
actual decompressed frame or an error - a silent data-loss bug.

The stream command decoders in `decode_stream.go` already guard against
exactly this class of overflow via `readBudget`; `Decompress` had the
same arithmetic but not the same guard. This adds a matching
`decompressBudget` helper and uses it in `Decompress`.

## Why
No exported API changes; this only fixes the internal budget
computation used by `Decompress`.

## Test plan
Added `TestFrameCodecDecompressMaxSizeOverflow` in `framecodec_test.go`:
compresses a small message and decompresses it back with
`maxSize = math.MaxInt`, asserting no error and an exact round trip.

- Before the fix: the test failed - `Decompress` returned `("", nil)`
  instead of the original message.
- After the fix: the test passes, and the message round-trips exactly.

Also ran:
- `go test ./...` - all pass
- `golangci-lint run ./...` - 0 issues