### PR TITLE
Make dictionary-compression level a caller-supplied parameter

### DIFF
--- a/framecodec.go
+++ b/framecodec.go
@@ -28,7 +28,8 @@ const (
 	FrameCodecCompressed byte = 0x01
 )
 
-// MinCompressionLevel is the lowest level NewDeflateFrameCodec accepts.
+// MinDictionaryCompressionLevel is the lowest level NewDeflateFrameCodec
+// accepts.
 //
 // DEFLATE implementations switch to specialised fast encoders below this which
 // ignore the preset dictionary completely while still accepting it. The
@@ -40,38 +41,7 @@ const (
 // one.
 //
 // TestFrameCodecDictionaryActuallyApplies guards this.
-const MinCompressionLevel = 2
-
-// DefaultCompressionLevel is what NewDeflateFrameCodec's callers should pass
-// absent a specific reason to deviate - centrifuge's own tests and examples,
-// and anything else with no independent basis for choosing differently.
-//
-// Measured on go1.26.5 and go1.27.0, frames drawn from the vocabulary a
-// dictionary is built from, against a few KB dictionary:
-//
-//   - go1.26: levels 2-9 are byte-identical in output and cost, because a
-//     per-frame compression there is dominated by loading the dictionary on
-//     Reset, not by encoding the frame - the level only governs the smaller
-//     half of the work.
-//   - go1.27 rewrote compress/flate's levels 2-6 into new encoders optimised
-//     for large-payload throughput (golang/go#75532), at the cost of ratio for
-//     a small payload against a large preset dictionary - exactly this
-//     codec's shape. A 40 byte frame against a 2.4KB dictionary compresses to
-//     47 bytes at level 6 on go1.27 (worse than sending it raw) versus 34
-//     bytes on go1.26. Levels 7-9 kept the old algorithm, so they are
-//     unaffected: 31 bytes on either Go version, at a CPU cost within a few
-//     percent of what level 6 cost on go1.26 - i.e. level 7 on go1.27 tracks
-//     the historical level-6 cost/ratio, where level 6 on go1.27 does not.
-//   - Levels 7, 8 and 9 produce byte-identical output for this shape, so 9
-//     buys nothing over 7 and only costs more CPU. There is no ratio reason to
-//     go above 7 here.
-//
-// A caller whose traffic or dictionaries look nothing like the above -
-// larger payloads, a much larger or smaller dictionary - may find a different
-// level wins for its own shape, which is why this is a parameter and not a
-// package constant: the answer depends on traffic only the caller sees, and
-// it has already moved once as compress/flate itself changed.
-const DefaultCompressionLevel = 7
+const MinDictionaryCompressionLevel = 2
 
 var (
 	// ErrFrameTooLarge is returned when a compressed frame expands beyond the
@@ -114,19 +84,42 @@ type DeflateFrameCodec struct {
 // the dictionary content so both sides can tell which one a frame was built
 // with.
 //
-// level is a DEFLATE compression level from MinCompressionLevel to 9, and
-// affects only how hard this side's encoder works to shrink a frame - see
-// DefaultCompressionLevel for why this package does not pick one for every
-// caller. It never needs to match what the other side of a connection uses:
-// DEFLATE's format is self-describing per block, so a decoder never depends on
-// which level produced its input, only on sharing the same dictionary.
-// NewDeflateFrameCodec panics if level is below MinCompressionLevel, since
-// that silently disables the dictionary rather than trading ratio for speed.
+// level is a DEFLATE compression level from MinDictionaryCompressionLevel to
+// 9. It affects only how hard this side's encoder works to shrink a frame,
+// and never needs to match what the other side of a connection uses: DEFLATE's
+// format is self-describing per block, so a decoder never depends on which
+// level produced its input, only on sharing the same dictionary.
+// NewDeflateFrameCodec panics if level is below MinDictionaryCompressionLevel,
+// since that silently disables the dictionary rather than trading ratio for
+// speed.
+//
+// This package does not recommend one level for every caller, because the
+// right choice depends on traffic and dictionary shapes only the caller sees,
+// and it has already moved once as compress/flate itself changed. Measured on
+// go1.26.5 and go1.27.0, frames drawn from the vocabulary a dictionary is
+// built from, against a few KB dictionary:
+//
+//   - go1.26: levels 2-9 are byte-identical in output and cost, because a
+//     per-frame compression there is dominated by loading the dictionary on
+//     Reset, not by encoding the frame - the level only governs the smaller
+//     half of the work.
+//   - go1.27 rewrote compress/flate's levels 2-6 into new encoders optimised
+//     for large-payload throughput (golang/go#75532), at the cost of ratio for
+//     a small payload against a large preset dictionary - exactly this
+//     codec's shape. A 40 byte frame against a 2.4KB dictionary compresses to
+//     47 bytes at level 6 on go1.27 (worse than sending it raw) versus 34
+//     bytes on go1.26. Levels 7-9 kept the old algorithm, so they are
+//     unaffected: 31 bytes on either Go version, at a CPU cost within a few
+//     percent of what level 6 cost on go1.26 - i.e. level 7 on go1.27 tracks
+//     the historical level-6 cost/ratio, where level 6 on go1.27 does not.
+//   - Levels 7, 8 and 9 produce byte-identical output for this shape, so 9
+//     buys nothing over 7 and only costs more CPU for a caller with this shape
+//     of traffic.
 func NewDeflateFrameCodec(id string, dict []byte, level int) *DeflateFrameCodec {
-	if level < MinCompressionLevel {
-		panic(fmt.Sprintf("centrifugal/protocol: dictionary compression level %d is below MinCompressionLevel (%d): "+
+	if level < MinDictionaryCompressionLevel {
+		panic(fmt.Sprintf("centrifugal/protocol: dictionary compression level %d is below MinDictionaryCompressionLevel (%d): "+
 			"levels below this silently ignore the preset dictionary instead of trading ratio for speed",
-			level, MinCompressionLevel))
+			level, MinDictionaryCompressionLevel))
 	}
 	c := &DeflateFrameCodec{id: id, dict: dict, level: level}
 	c.wPool.New = func() any {
@@ -227,7 +220,7 @@ func decompressBudget(maxSize int) int64 {
 //
 // level is a plain flate.NewWriter level: unlike NewDeflateFrameCodec's level,
 // there is no preset dictionary here for a low level to silently ignore, so
-// any valid flate level is fine - MinCompressionLevel does not apply.
+// any valid flate level is fine - MinDictionaryCompressionLevel does not apply.
 func DeflateDictionary(dict []byte, level int) []byte {
 	var buf bytes.Buffer
 	w, err := flate.NewWriter(&buf, level)

--- a/framecodec.go
+++ b/framecodec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"sync"
@@ -27,36 +28,50 @@ const (
 	FrameCodecCompressed byte = 0x01
 )
 
-// frameCompressionLevel must stay at 2 or above, and this is load bearing.
+// MinCompressionLevel is the lowest level NewDeflateFrameCodec accepts.
 //
-// DEFLATE implementations switch to specialised fast encoders at low levels
-// which ignore the preset dictionary completely while still accepting it. The
+// DEFLATE implementations switch to specialised fast encoders below this which
+// ignore the preset dictionary completely while still accepting it. The
 // standard library does this at level 1: measured on a 61 byte frame against a
 // 4KB dictionary it emits 66 bytes, versus 24 bytes at level 2 and above and 60
-// bytes with no dictionary at all. Lowering this constant therefore does not
-// trade ratio for speed, it silently disables the entire feature while still
-// paying to carry the dictionary around.
+// bytes with no dictionary at all. A level below this does not trade ratio for
+// speed, it silently disables the entire feature while still paying to carry
+// the dictionary around - so NewDeflateFrameCodec panics rather than accept
+// one.
 //
 // TestFrameCodecDictionaryActuallyApplies guards this.
+const MinCompressionLevel = 2
+
+// DefaultCompressionLevel is what NewDeflateFrameCodec's callers should pass
+// absent a specific reason to deviate - centrifuge's own tests and examples,
+// and anything else with no independent basis for choosing differently.
 //
-// Why 6 rather than the floor: there is no speed to buy below it. Levels 2 and
-// 4 were measured against 6 on frames drawn from the vocabulary a dictionary is
-// built from, and 6 won on both axes - better than 4 on ratio and time alike,
-// and 16% better than 2 on ratio for about 6% more time. The reason is that a
-// per-frame compression is dominated by loading the dictionary on Reset, not by
-// encoding the frame, so the level only governs the smaller half of the work.
-// Above 6 there is nothing left: 7 and 9 produce byte-identical output.
+// Measured on go1.26.5 and go1.27.0, frames drawn from the vocabulary a
+// dictionary is built from, against a few KB dictionary:
 //
-// It is a constant and not a setting for the same reason. The interesting range
-// is one value wide, and the values outside it are a cliff rather than a
-// trade - so a knob here could only be set wrong.
+//   - go1.26: levels 2-9 are byte-identical in output and cost, because a
+//     per-frame compression there is dominated by loading the dictionary on
+//     Reset, not by encoding the frame - the level only governs the smaller
+//     half of the work.
+//   - go1.27 rewrote compress/flate's levels 2-6 into new encoders optimised
+//     for large-payload throughput (golang/go#75532), at the cost of ratio for
+//     a small payload against a large preset dictionary - exactly this
+//     codec's shape. A 40 byte frame against a 2.4KB dictionary compresses to
+//     47 bytes at level 6 on go1.27 (worse than sending it raw) versus 34
+//     bytes on go1.26. Levels 7-9 kept the old algorithm, so they are
+//     unaffected: 31 bytes on either Go version, at a CPU cost within a few
+//     percent of what level 6 cost on go1.26 - i.e. level 7 on go1.27 tracks
+//     the historical level-6 cost/ratio, where level 6 on go1.27 does not.
+//   - Levels 7, 8 and 9 produce byte-identical output for this shape, so 9
+//     buys nothing over 7 and only costs more CPU. There is no ratio reason to
+//     go above 7 here.
 //
-// klauspost/compress was evaluated as a faster encoder and rejected: it ignores
-// the dictionary below level 7, and at level 7 it was only ~1.25x cheaper while
-// producing ~6% more bytes overall on real traffic. Once the shared frame cache
-// removed the fan-out multiplier, per-frame encode cost stopped being the
-// bottleneck, so the extra dependency in this package was not worth it.
-const frameCompressionLevel = 6
+// A caller whose traffic or dictionaries look nothing like the above -
+// larger payloads, a much larger or smaller dictionary - may find a different
+// level wins for its own shape, which is why this is a parameter and not a
+// package constant: the answer depends on traffic only the caller sees, and
+// it has already moved once as compress/flate itself changed.
+const DefaultCompressionLevel = 7
 
 var (
 	// ErrFrameTooLarge is returned when a compressed frame expands beyond the
@@ -90,6 +105,7 @@ var (
 type DeflateFrameCodec struct {
 	id    string
 	dict  []byte
+	level int
 	wPool sync.Pool
 	rPool sync.Pool
 }
@@ -97,10 +113,24 @@ type DeflateFrameCodec struct {
 // NewDeflateFrameCodec builds a codec for the given dictionary. id identifies
 // the dictionary content so both sides can tell which one a frame was built
 // with.
-func NewDeflateFrameCodec(id string, dict []byte) *DeflateFrameCodec {
-	c := &DeflateFrameCodec{id: id, dict: dict}
+//
+// level is a DEFLATE compression level from MinCompressionLevel to 9, and
+// affects only how hard this side's encoder works to shrink a frame - see
+// DefaultCompressionLevel for why this package does not pick one for every
+// caller. It never needs to match what the other side of a connection uses:
+// DEFLATE's format is self-describing per block, so a decoder never depends on
+// which level produced its input, only on sharing the same dictionary.
+// NewDeflateFrameCodec panics if level is below MinCompressionLevel, since
+// that silently disables the dictionary rather than trading ratio for speed.
+func NewDeflateFrameCodec(id string, dict []byte, level int) *DeflateFrameCodec {
+	if level < MinCompressionLevel {
+		panic(fmt.Sprintf("centrifugal/protocol: dictionary compression level %d is below MinCompressionLevel (%d): "+
+			"levels below this silently ignore the preset dictionary instead of trading ratio for speed",
+			level, MinCompressionLevel))
+	}
+	c := &DeflateFrameCodec{id: id, dict: dict, level: level}
 	c.wPool.New = func() any {
-		w, _ := flate.NewWriterDict(io.Discard, frameCompressionLevel, c.dict)
+		w, _ := flate.NewWriterDict(io.Discard, c.level, c.dict)
 		return w
 	}
 	c.rPool.New = func() any {
@@ -194,9 +224,13 @@ func decompressBudget(maxSize int) int64 {
 // A dictionary is a concatenation of real message samples, so it is ordinary
 // text and compresses several fold - which is the difference between a first
 // dictionary a connection can afford and one it cannot.
-func DeflateDictionary(dict []byte) []byte {
+//
+// level is a plain flate.NewWriter level: unlike NewDeflateFrameCodec's level,
+// there is no preset dictionary here for a low level to silently ignore, so
+// any valid flate level is fine - MinCompressionLevel does not apply.
+func DeflateDictionary(dict []byte, level int) []byte {
 	var buf bytes.Buffer
-	w, err := flate.NewWriter(&buf, frameCompressionLevel)
+	w, err := flate.NewWriter(&buf, level)
 	if err != nil {
 		return nil
 	}

--- a/framecodec_test.go
+++ b/framecodec_test.go
@@ -7,9 +7,14 @@ import (
 	"testing"
 )
 
+// testCompressionLevel is an arbitrary valid level for tests that exercise
+// something other than level choice itself - not a recommendation, just a
+// fixed value so those tests don't each have to pick one.
+const testCompressionLevel = 7
+
 func TestFrameCodecRoundTrip(t *testing.T) {
 	dict := []byte(`{"push":{"id":,"pub":{"data":{"offset":`)
-	c := NewDeflateFrameCodec("v1", dict, 7)
+	c := NewDeflateFrameCodec("v1", dict, testCompressionLevel)
 	msg := []byte(`{"push":{"id":7,"pub":{"data":{"price":123.45},"offset":42}}}`)
 	fr := c.Compress(nil, msg)
 	out, err := c.Decompress(nil, fr, 1<<20)
@@ -41,7 +46,7 @@ func TestFrameCodecRoundTrip(t *testing.T) {
 
 func TestFrameCodecConcurrent(t *testing.T) {
 	dict := []byte(`{"push":{"id":,"pub":{"data":`)
-	c := NewDeflateFrameCodec("v1", dict, 7)
+	c := NewDeflateFrameCodec("v1", dict, testCompressionLevel)
 	done := make(chan bool, 8)
 	for g := 0; g < 8; g++ {
 		go func(g int) {
@@ -62,7 +67,7 @@ func TestFrameCodecConcurrent(t *testing.T) {
 }
 
 func TestFrameCodecDecompressErrors(t *testing.T) {
-	c := NewDeflateFrameCodec("v1", []byte("dict"), 7)
+	c := NewDeflateFrameCodec("v1", []byte("dict"), testCompressionLevel)
 
 	if _, err := c.Decompress(nil, nil, 0); err != ErrEmptyFrame {
 		t.Fatalf("expected ErrEmptyFrame for empty frame, got %v", err)
@@ -78,7 +83,7 @@ func TestFrameCodecDecompressErrors(t *testing.T) {
 // error instead of the decompressed frame.
 func TestFrameCodecDecompressMaxSizeOverflow(t *testing.T) {
 	dict := []byte("some dictionary content used for compression testing 1234567890")
-	c := NewDeflateFrameCodec("v1", dict, 7)
+	c := NewDeflateFrameCodec("v1", dict, testCompressionLevel)
 	msg := []byte("hello world hello world hello world hello world")
 	fr := c.Compress(nil, msg)
 	out, err := c.Decompress(nil, fr, math.MaxInt)
@@ -89,7 +94,7 @@ func TestFrameCodecDecompressMaxSizeOverflow(t *testing.T) {
 
 func TestFrameCodecAccessors(t *testing.T) {
 	dict := []byte("some dictionary content")
-	c := NewDeflateFrameCodec("v42", dict, 7)
+	c := NewDeflateFrameCodec("v42", dict, testCompressionLevel)
 	if c.ID() != "v42" {
 		t.Fatalf("unexpected ID: %s", c.ID())
 	}
@@ -100,7 +105,7 @@ func TestFrameCodecAccessors(t *testing.T) {
 
 func TestDeflateDictionaryRoundTrip(t *testing.T) {
 	dict := bytes.Repeat([]byte(`{"push":{"id":3,"pub":{"data":{}}}}`), 50)
-	compressed := DeflateDictionary(dict, 7)
+	compressed := DeflateDictionary(dict, testCompressionLevel)
 	if len(compressed) == 0 {
 		t.Fatal("DeflateDictionary returned empty output")
 	}
@@ -118,7 +123,7 @@ func TestDeflateDictionaryRoundTrip(t *testing.T) {
 
 func TestInflateDictionaryTooLarge(t *testing.T) {
 	dict := bytes.Repeat([]byte("x"), 1000)
-	compressed := DeflateDictionary(dict, 7)
+	compressed := DeflateDictionary(dict, testCompressionLevel)
 	if _, err := InflateDictionary(compressed, len(dict)-1); err == nil {
 		t.Fatal("expected an error when inflated dictionary exceeds maxSize")
 	}
@@ -152,8 +157,8 @@ func TestFrameCodecDictionaryActuallyApplies(t *testing.T) {
 	}
 	msg := []byte(`{"push":{"id":7,"pub":{"data":{"price":123.45},"offset":42}}}`)
 
-	withDict := NewDeflateFrameCodec("v", d.Bytes()[:4096], 7)
-	noDict := NewDeflateFrameCodec("v", nil, 7)
+	withDict := NewDeflateFrameCodec("v", d.Bytes()[:4096], testCompressionLevel)
+	noDict := NewDeflateFrameCodec("v", nil, testCompressionLevel)
 
 	got := len(withDict.Compress(nil, msg))
 	baseline := len(noDict.Compress(nil, msg))

--- a/framecodec_test.go
+++ b/framecodec_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFrameCodecRoundTrip(t *testing.T) {
 	dict := []byte(`{"push":{"id":,"pub":{"data":{"offset":`)
-	c := NewDeflateFrameCodec("v1", dict)
+	c := NewDeflateFrameCodec("v1", dict, DefaultCompressionLevel)
 	msg := []byte(`{"push":{"id":7,"pub":{"data":{"price":123.45},"offset":42}}}`)
 	fr := c.Compress(nil, msg)
 	out, err := c.Decompress(nil, fr, 1<<20)
@@ -41,7 +41,7 @@ func TestFrameCodecRoundTrip(t *testing.T) {
 
 func TestFrameCodecConcurrent(t *testing.T) {
 	dict := []byte(`{"push":{"id":,"pub":{"data":`)
-	c := NewDeflateFrameCodec("v1", dict)
+	c := NewDeflateFrameCodec("v1", dict, DefaultCompressionLevel)
 	done := make(chan bool, 8)
 	for g := 0; g < 8; g++ {
 		go func(g int) {
@@ -62,7 +62,7 @@ func TestFrameCodecConcurrent(t *testing.T) {
 }
 
 func TestFrameCodecDecompressErrors(t *testing.T) {
-	c := NewDeflateFrameCodec("v1", []byte("dict"))
+	c := NewDeflateFrameCodec("v1", []byte("dict"), DefaultCompressionLevel)
 
 	if _, err := c.Decompress(nil, nil, 0); err != ErrEmptyFrame {
 		t.Fatalf("expected ErrEmptyFrame for empty frame, got %v", err)
@@ -78,7 +78,7 @@ func TestFrameCodecDecompressErrors(t *testing.T) {
 // error instead of the decompressed frame.
 func TestFrameCodecDecompressMaxSizeOverflow(t *testing.T) {
 	dict := []byte("some dictionary content used for compression testing 1234567890")
-	c := NewDeflateFrameCodec("v1", dict)
+	c := NewDeflateFrameCodec("v1", dict, DefaultCompressionLevel)
 	msg := []byte("hello world hello world hello world hello world")
 	fr := c.Compress(nil, msg)
 	out, err := c.Decompress(nil, fr, math.MaxInt)
@@ -89,7 +89,7 @@ func TestFrameCodecDecompressMaxSizeOverflow(t *testing.T) {
 
 func TestFrameCodecAccessors(t *testing.T) {
 	dict := []byte("some dictionary content")
-	c := NewDeflateFrameCodec("v42", dict)
+	c := NewDeflateFrameCodec("v42", dict, DefaultCompressionLevel)
 	if c.ID() != "v42" {
 		t.Fatalf("unexpected ID: %s", c.ID())
 	}
@@ -100,7 +100,7 @@ func TestFrameCodecAccessors(t *testing.T) {
 
 func TestDeflateDictionaryRoundTrip(t *testing.T) {
 	dict := bytes.Repeat([]byte(`{"push":{"id":3,"pub":{"data":{}}}}`), 50)
-	compressed := DeflateDictionary(dict)
+	compressed := DeflateDictionary(dict, DefaultCompressionLevel)
 	if len(compressed) == 0 {
 		t.Fatal("DeflateDictionary returned empty output")
 	}
@@ -118,10 +118,23 @@ func TestDeflateDictionaryRoundTrip(t *testing.T) {
 
 func TestInflateDictionaryTooLarge(t *testing.T) {
 	dict := bytes.Repeat([]byte("x"), 1000)
-	compressed := DeflateDictionary(dict)
+	compressed := DeflateDictionary(dict, DefaultCompressionLevel)
 	if _, err := InflateDictionary(compressed, len(dict)-1); err == nil {
 		t.Fatal("expected an error when inflated dictionary exceeds maxSize")
 	}
+}
+
+// TestNewDeflateFrameCodecRejectsLowLevel guards MinCompressionLevel: a level
+// below it silently drops the dictionary instead of trading ratio for speed,
+// so NewDeflateFrameCodec must refuse it rather than build a codec that looks
+// fine but never compresses against its dictionary.
+func TestNewDeflateFrameCodecRejectsLowLevel(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected NewDeflateFrameCodec to panic for a level below MinCompressionLevel")
+		}
+	}()
+	NewDeflateFrameCodec("v1", []byte("dict"), MinCompressionLevel-1)
 }
 
 // TestFrameCodecDictionaryActuallyApplies fails if the configured compression
@@ -139,8 +152,8 @@ func TestFrameCodecDictionaryActuallyApplies(t *testing.T) {
 	}
 	msg := []byte(`{"push":{"id":7,"pub":{"data":{"price":123.45},"offset":42}}}`)
 
-	withDict := NewDeflateFrameCodec("v", d.Bytes()[:4096])
-	noDict := NewDeflateFrameCodec("v", nil)
+	withDict := NewDeflateFrameCodec("v", d.Bytes()[:4096], DefaultCompressionLevel)
+	noDict := NewDeflateFrameCodec("v", nil, DefaultCompressionLevel)
 
 	got := len(withDict.Compress(nil, msg))
 	baseline := len(noDict.Compress(nil, msg))

--- a/framecodec_test.go
+++ b/framecodec_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFrameCodecRoundTrip(t *testing.T) {
 	dict := []byte(`{"push":{"id":,"pub":{"data":{"offset":`)
-	c := NewDeflateFrameCodec("v1", dict, DefaultCompressionLevel)
+	c := NewDeflateFrameCodec("v1", dict, 7)
 	msg := []byte(`{"push":{"id":7,"pub":{"data":{"price":123.45},"offset":42}}}`)
 	fr := c.Compress(nil, msg)
 	out, err := c.Decompress(nil, fr, 1<<20)
@@ -41,7 +41,7 @@ func TestFrameCodecRoundTrip(t *testing.T) {
 
 func TestFrameCodecConcurrent(t *testing.T) {
 	dict := []byte(`{"push":{"id":,"pub":{"data":`)
-	c := NewDeflateFrameCodec("v1", dict, DefaultCompressionLevel)
+	c := NewDeflateFrameCodec("v1", dict, 7)
 	done := make(chan bool, 8)
 	for g := 0; g < 8; g++ {
 		go func(g int) {
@@ -62,7 +62,7 @@ func TestFrameCodecConcurrent(t *testing.T) {
 }
 
 func TestFrameCodecDecompressErrors(t *testing.T) {
-	c := NewDeflateFrameCodec("v1", []byte("dict"), DefaultCompressionLevel)
+	c := NewDeflateFrameCodec("v1", []byte("dict"), 7)
 
 	if _, err := c.Decompress(nil, nil, 0); err != ErrEmptyFrame {
 		t.Fatalf("expected ErrEmptyFrame for empty frame, got %v", err)
@@ -78,7 +78,7 @@ func TestFrameCodecDecompressErrors(t *testing.T) {
 // error instead of the decompressed frame.
 func TestFrameCodecDecompressMaxSizeOverflow(t *testing.T) {
 	dict := []byte("some dictionary content used for compression testing 1234567890")
-	c := NewDeflateFrameCodec("v1", dict, DefaultCompressionLevel)
+	c := NewDeflateFrameCodec("v1", dict, 7)
 	msg := []byte("hello world hello world hello world hello world")
 	fr := c.Compress(nil, msg)
 	out, err := c.Decompress(nil, fr, math.MaxInt)
@@ -89,7 +89,7 @@ func TestFrameCodecDecompressMaxSizeOverflow(t *testing.T) {
 
 func TestFrameCodecAccessors(t *testing.T) {
 	dict := []byte("some dictionary content")
-	c := NewDeflateFrameCodec("v42", dict, DefaultCompressionLevel)
+	c := NewDeflateFrameCodec("v42", dict, 7)
 	if c.ID() != "v42" {
 		t.Fatalf("unexpected ID: %s", c.ID())
 	}
@@ -100,7 +100,7 @@ func TestFrameCodecAccessors(t *testing.T) {
 
 func TestDeflateDictionaryRoundTrip(t *testing.T) {
 	dict := bytes.Repeat([]byte(`{"push":{"id":3,"pub":{"data":{}}}}`), 50)
-	compressed := DeflateDictionary(dict, DefaultCompressionLevel)
+	compressed := DeflateDictionary(dict, 7)
 	if len(compressed) == 0 {
 		t.Fatal("DeflateDictionary returned empty output")
 	}
@@ -118,23 +118,23 @@ func TestDeflateDictionaryRoundTrip(t *testing.T) {
 
 func TestInflateDictionaryTooLarge(t *testing.T) {
 	dict := bytes.Repeat([]byte("x"), 1000)
-	compressed := DeflateDictionary(dict, DefaultCompressionLevel)
+	compressed := DeflateDictionary(dict, 7)
 	if _, err := InflateDictionary(compressed, len(dict)-1); err == nil {
 		t.Fatal("expected an error when inflated dictionary exceeds maxSize")
 	}
 }
 
-// TestNewDeflateFrameCodecRejectsLowLevel guards MinCompressionLevel: a level
+// TestNewDeflateFrameCodecRejectsLowLevel guards MinDictionaryCompressionLevel: a level
 // below it silently drops the dictionary instead of trading ratio for speed,
 // so NewDeflateFrameCodec must refuse it rather than build a codec that looks
 // fine but never compresses against its dictionary.
 func TestNewDeflateFrameCodecRejectsLowLevel(t *testing.T) {
 	defer func() {
 		if recover() == nil {
-			t.Fatal("expected NewDeflateFrameCodec to panic for a level below MinCompressionLevel")
+			t.Fatal("expected NewDeflateFrameCodec to panic for a level below MinDictionaryCompressionLevel")
 		}
 	}()
-	NewDeflateFrameCodec("v1", []byte("dict"), MinCompressionLevel-1)
+	NewDeflateFrameCodec("v1", []byte("dict"), MinDictionaryCompressionLevel-1)
 }
 
 // TestFrameCodecDictionaryActuallyApplies fails if the configured compression
@@ -152,8 +152,8 @@ func TestFrameCodecDictionaryActuallyApplies(t *testing.T) {
 	}
 	msg := []byte(`{"push":{"id":7,"pub":{"data":{"price":123.45},"offset":42}}}`)
 
-	withDict := NewDeflateFrameCodec("v", d.Bytes()[:4096], DefaultCompressionLevel)
-	noDict := NewDeflateFrameCodec("v", nil, DefaultCompressionLevel)
+	withDict := NewDeflateFrameCodec("v", d.Bytes()[:4096], 7)
+	noDict := NewDeflateFrameCodec("v", nil, 7)
 
 	got := len(withDict.Compress(nil, msg))
 	baseline := len(noDict.Compress(nil, msg))


### PR DESCRIPTION
## Summary

`NewDeflateFrameCodec` and `DeflateDictionary` hard-coded a single DEFLATE level (6), chosen by benchmarking against pre-Go-1.27 `compress/flate` behavior: at the time, levels 2-9 were byte-identical in output and cost for this codec's workload (a small payload against a preset dictionary), so there was no real trade-off to expose - `frameCompressionLevel` was a package constant, not a setting, by design.

Go 1.27 rewrote `compress/flate`'s levels 2-6 into new encoders optimised for large-payload throughput ([golang/go#75532](https://github.com/golang/go/issues/75532)), at the cost of ratio for exactly this codec's shape - a small payload against a large preset dictionary:

| | go1.26 | go1.27 |
|---|---|---|
| level 6, 40B frame vs 2.4KB dict | 34 bytes | **47 bytes** (worse than raw) |
| level 7, same frame/dict | 34 bytes | 31 bytes |

Levels 7-9 kept the old algorithm and are unaffected - 31 bytes on either Go version, at a CPU cost within a few percent of what level 6 cost on go1.26. Levels 7, 8, 9 are also byte-identical to each other for this shape, so 9 buys nothing over 7.

This is the second time a Go stdlib change has invalidated this package's own assumption about where the useful range sits (see the old `frameCompressionLevel` doc comment's own klauspost/compress evaluation). Which level is right depends on traffic and dictionary shapes only the caller sees - so this PR turns level into a required parameter instead of a package constant.

## Changes

- `NewDeflateFrameCodec(id, dict)` → `NewDeflateFrameCodec(id, dict, level)`. Panics if `level < MinDictionaryCompressionLevel`: a level below 2 silently drops the preset dictionary entirely rather than trading ratio for speed, which is a hazard worth refusing outright regardless of who picked the number.
- `DeflateDictionary(dict)` → `DeflateDictionary(dict, level)`. No preset dictionary is involved in this path (it compresses the dictionary blob itself for initial delivery), so `MinDictionaryCompressionLevel` doesn't apply there - any valid `flate` level works.
- New exported constant: `MinDictionaryCompressionLevel = 2` - a mechanical floor, not a recommendation. There is deliberately no exported "default" level: the measurements behind a reasonable choice (7, for the workload described above) are documented on `NewDeflateFrameCodec`'s `level` parameter as prose, but this package does not pick one for every caller, since doing so would reintroduce the same one-size-fits-all assumption this PR removes.
- Doc comments rewritten with the actual go1.26/go1.27 measurements.
- New test: `NewDeflateFrameCodec` panics for a level below `MinDictionaryCompressionLevel`.

## Compatibility

Breaking API change. This is fine: `DictionaryCompression` is `EXPERIMENTAL` and not yet released in any Centrifuge/Centrifugo version, so there are no external callers to migrate. Follow-up PRs will update `centrifuge`'s tests/examples, `benchsuite`, and Centrifugo PRO's `dictserve`/`dictcomp`/`vocab` call sites to pass an explicit level.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` - all passing, including the new panic test