### PR TITLE
Fix InflateDictionary silently truncating with maxSize=math.MaxInt

### DIFF
--- a/framecodec.go
+++ b/framecodec.go
@@ -242,7 +242,10 @@ func DeflateDictionary(dict []byte, level int) []byte {
 func InflateDictionary(data []byte, maxSize int) ([]byte, error) {
 	r := flate.NewReader(bytes.NewReader(data))
 	defer func() { _ = r.Close() }()
-	out, err := io.ReadAll(io.LimitReader(r, int64(maxSize)+1))
+	// decompressBudget avoids the int64(maxSize)+1 overflow when maxSize is
+	// math.MaxInt, which would otherwise silently truncate the output to
+	// nothing instead of decompressing it.
+	out, err := io.ReadAll(io.LimitReader(r, decompressBudget(maxSize)))
 	if err != nil {
 		return nil, err
 	}

--- a/framecodec_test.go
+++ b/framecodec_test.go
@@ -92,6 +92,18 @@ func TestFrameCodecDecompressMaxSizeOverflow(t *testing.T) {
 	}
 }
 
+// TestInflateDictionaryMaxSizeOverflow is InflateDictionary's counterpart to
+// TestFrameCodecDecompressMaxSizeOverflow: it has the same int64(maxSize)+1
+// overflow hazard when maxSize is math.MaxInt.
+func TestInflateDictionaryMaxSizeOverflow(t *testing.T) {
+	dict := []byte("some dictionary content used for compression testing 1234567890")
+	compressed := DeflateDictionary(dict, testCompressionLevel)
+	out, err := InflateDictionary(compressed, math.MaxInt)
+	if err != nil || !bytes.Equal(out, dict) {
+		t.Fatalf("round trip with maxSize=math.MaxInt failed: err=%v out=%q", err, out)
+	}
+}
+
 func TestFrameCodecAccessors(t *testing.T) {
 	dict := []byte("some dictionary content")
 	c := NewDeflateFrameCodec("v42", dict, testCompressionLevel)


### PR DESCRIPTION
## What

`InflateDictionary` computed its `io.LimitReader` budget as `int64(maxSize)+1`. When `maxSize == math.MaxInt`, this overflows to a negative `int64`, and `io.LimitReader` with a negative limit reads zero bytes with no error — so the call silently returns an empty result instead of the decompressed dictionary (or an error).

## Why

`Decompress` on `DeflateFrameCodec` had the exact same overflow hazard and was fixed in #48 by introducing a `decompressBudget` helper that special-cases `math.MaxInt`. `InflateDictionary` has the identical `int64(maxSize)+1` pattern but was never updated to use that helper, so the bug still exists on this second code path.

## Change

`InflateDictionary` now computes its `io.LimitReader` budget via the existing `decompressBudget` helper instead of the raw `int64(maxSize)+1` expression, matching what `Decompress` already does.

## Verification

Added `TestInflateDictionaryMaxSizeOverflow`, mirroring the existing `TestFrameCodecDecompressMaxSizeOverflow`: it round-trips a dictionary through `DeflateDictionary`/`InflateDictionary` with `maxSize = math.MaxInt` and asserts the original content comes back.

- Confirmed it fails against the old code: `err=<nil> out=""` (silent truncation to empty output).
- Confirmed it passes with the fix.
- Ran the full suite: `go build ./...` and `go test -race -count=1 ./...` — both pass.

Kept the test permanently: it's a real regression class (any caller passing an unbounded/`math.MaxInt` size limit), not redundant with existing coverage, and not tied to internals beyond the public `InflateDictionary` API.