### PR TITLE
Add tests for reply decoders

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -156,6 +156,23 @@ func TestProtobufCommandDecoder_Decode_ShortData(t *testing.T) {
 	}
 }
 
+func readReplies(t testing.TB, decoder ReplyDecoder) []*Reply {
+	t.Helper()
+	var replies []*Reply
+	for {
+		reply, err := decoder.Decode()
+		if err != nil {
+			// Unlike CommandDecoder, a ReplyDecoder signals the end of a frame
+			// with io.EOF on its own, without a Reply attached to it.
+			require.ErrorIs(t, err, io.EOF)
+			require.Nil(t, reply)
+			break
+		}
+		replies = append(replies, reply)
+	}
+	return replies
+}
+
 func TestProtobufReplyDecoder_Decode_Many(t *testing.T) {
 	encoder := NewProtobufDataEncoder()
 	replyEncoder := NewProtobufReplyEncoder()
@@ -165,16 +182,7 @@ func TestProtobufReplyDecoder_Decode_Many(t *testing.T) {
 		require.NoError(t, encoder.Encode(replyData))
 	}
 
-	decoder := NewProtobufReplyDecoder(encoder.Finish())
-	var replies []*Reply
-	for {
-		reply, err := decoder.Decode()
-		if err != nil {
-			require.ErrorIs(t, err, io.EOF)
-			break
-		}
-		replies = append(replies, reply)
-	}
+	replies := readReplies(t, NewProtobufReplyDecoder(encoder.Finish()))
 	require.Len(t, replies, 2)
 	if len(replies) == 2 { // Make Goland happy.
 		require.Equal(t, uint32(1), replies[0].Id)
@@ -219,4 +227,108 @@ func TestProtobufReplyDecoder_Decode_Malformed(t *testing.T) {
 			require.ErrorIs(t, err, tt.err)
 		})
 	}
+}
+
+func TestJSONReplyDecoder_Decode_Many(t *testing.T) {
+	dataEncoder := NewJSONDataEncoder()
+	replyEncoder := NewJSONReplyEncoder()
+	for _, id := range []uint32{1, 2} {
+		replyData, err := replyEncoder.Encode(&Reply{Id: id, Connect: &ConnectResult{Client: "client"}})
+		require.NoError(t, err)
+		require.NoError(t, dataEncoder.Encode(replyData))
+	}
+
+	replies := readReplies(t, NewJSONReplyDecoder(dataEncoder.Finish()))
+	require.Len(t, replies, 2)
+	if len(replies) == 2 { // Make Goland happy.
+		require.Equal(t, uint32(1), replies[0].Id)
+		require.Equal(t, uint32(2), replies[1].Id)
+		require.Equal(t, "client", replies[0].Connect.Client)
+	}
+}
+
+func TestJSONReplyDecoder_Decode_Empty(t *testing.T) {
+	require.Empty(t, readReplies(t, NewJSONReplyDecoder(nil)))
+}
+
+// A Raw payload may contain a raw newline, which is exactly what delimits
+// replies inside a JSON frame. Raw.MarshalJSON strips those on encode so that a
+// payload cannot inject a delimiter into the frame - this asserts the whole
+// round trip, since a client which splits a frame on `\n` (as SDKs in other
+// languages do) would otherwise see the publication torn in two.
+func TestJSONReplyDecoder_Decode_PayloadWithNewline(t *testing.T) {
+	dataEncoder := NewJSONDataEncoder()
+	replyEncoder := NewJSONReplyEncoder()
+
+	pubReply, err := replyEncoder.Encode(&Reply{
+		Push: &Push{Channel: "chat:1", Pub: &Publication{Data: Raw("{\"num\":\n1}")}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dataEncoder.Encode(pubReply))
+	nextReply, err := replyEncoder.Encode(&Reply{Id: 7})
+	require.NoError(t, err)
+	require.NoError(t, dataEncoder.Encode(nextReply))
+
+	replies := readReplies(t, NewJSONReplyDecoder(dataEncoder.Finish()))
+	require.Len(t, replies, 2)
+	if len(replies) == 2 { // Make Goland happy.
+		require.Equal(t, "chat:1", replies[0].Push.Channel)
+		require.Equal(t, Raw(`{"num":1}`), replies[0].Push.Pub.Data)
+		require.Equal(t, uint32(7), replies[1].Id)
+	}
+}
+
+// Replies come from a server, so malformed input must produce an error instead
+// of a panic.
+func TestJSONReplyDecoder_Decode_Malformed(t *testing.T) {
+	decoder := NewJSONReplyDecoder([]byte(`{"id": 1}` + "\n" + `{"id": `))
+	reply, err := decoder.Decode()
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), reply.Id)
+	_, err = decoder.Decode()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, io.EOF)
+}
+
+func TestJSONReplyDecoder_Reset(t *testing.T) {
+	replyEncoder := NewJSONReplyEncoder()
+	first, err := replyEncoder.Encode(&Reply{Id: 1})
+	require.NoError(t, err)
+	second, err := replyEncoder.Encode(&Reply{Id: 2})
+	require.NoError(t, err)
+
+	decoder := NewJSONReplyDecoder(first)
+	replies := readReplies(t, decoder)
+	require.Len(t, replies, 1)
+
+	require.NoError(t, decoder.Reset(second))
+	replies = readReplies(t, decoder)
+	require.Len(t, replies, 1)
+	require.Equal(t, uint32(2), replies[0].Id)
+}
+
+func TestProtobufReplyDecoder_Reset(t *testing.T) {
+	replyEncoder := NewProtobufReplyEncoder()
+	dataEncoder := NewProtobufDataEncoder()
+	replyData, err := replyEncoder.Encode(&Reply{Id: 1})
+	require.NoError(t, err)
+	require.NoError(t, dataEncoder.Encode(replyData))
+	first := dataEncoder.Finish()
+
+	dataEncoder.Reset()
+	replyData, err = replyEncoder.Encode(&Reply{Id: 2})
+	require.NoError(t, err)
+	require.NoError(t, dataEncoder.Encode(replyData))
+	second := dataEncoder.Finish()
+
+	decoder := NewProtobufReplyDecoder(first)
+	replies := readReplies(t, decoder)
+	require.Len(t, replies, 1)
+
+	// Reset must rewind the offset, not just swap the frame - otherwise the
+	// second frame would be reported as fully consumed already.
+	require.NoError(t, decoder.Reset(second))
+	replies = readReplies(t, decoder)
+	require.Len(t, replies, 1)
+	require.Equal(t, uint32(2), replies[0].Id)
 }


### PR DESCRIPTION
## What

Adds test coverage for the `ReplyDecoder` implementations — the client-side decode path.

`JSONReplyDecoder` had **no tests at all** (0% on both `Reset` and `Decode`), and `ProtobufReplyDecoder.Reset` was untested as well. They are the only decoders in the package in that state; the command decoders, the stream decoders and the frame codec are all covered.

New tests:

- `TestJSONReplyDecoder_Decode_Many` — a multi-reply frame built with `JSONReplyEncoder` + `JSONDataEncoder` round-trips back through `JSONReplyDecoder`.
- `TestJSONReplyDecoder_Decode_Empty` — an empty frame yields `io.EOF` immediately.
- `TestJSONReplyDecoder_Decode_PayloadWithNewline` — a `Raw` publication payload containing a raw newline (the very byte JSON framing uses as its delimiter) survives the encode → frame → decode round trip, and the reply after it still decodes.
- `TestJSONReplyDecoder_Decode_Malformed` — truncated JSON produces an error rather than a panic or a silent `io.EOF`.
- `TestJSONReplyDecoder_Reset` / `TestProtobufReplyDecoder_Reset` — a decoder reused across frames decodes the second frame from its start.

Also factors the reply-reading loop out of `TestProtobufReplyDecoder_Decode_Many` into a `readReplies` helper shared by all of them. The helper additionally asserts the part of the `ReplyDecoder` contract that differs from `CommandDecoder`: `io.EOF` arrives on its own, with a nil `Reply`, rather than attached to the last one.

No production code changes.

## Why

These are exported API. Anything implementing a client, a transport, or tooling that speaks the protocol decodes replies through them, and until now nothing exercised the JSON one.

## Verification

`make test` (`go test -race -count=1 ./...`) passes, and `make lint` (golangci-lint, pinned version) reports 0 issues.

Since this PR only adds tests, I checked the new tests actually bite by mutating the code they cover and confirming they fail:

- Dropping `d.offset = 0` from `ProtobufReplyDecoder.Reset` → `TestProtobufReplyDecoder_Reset` fails with `"[]" should have 1 item(s), but has 0` (the second frame is reported as already consumed). Passes again once restored.
- Making `Raw.MarshalJSON` return the payload without stripping newlines → `TestJSONReplyDecoder_Decode_PayloadWithNewline` fails on the payload assertion, showing the raw `\n` leaking into the decoded `Publication.Data` (`{"num":\n1}` vs `{"num":1}`). Passes again once restored.

Both mutations were reverted; the diff contains only the test file. Coverage for `JSONReplyDecoder.Reset`/`Decode` and `ProtobufReplyDecoder.Reset` goes from 0% to 100%.