### PR TITLE
Add tests for DeflateFrameCodec and InflateDictionary on corrupt input

### DIFF
--- a/framecodec_test.go
+++ b/framecodec_test.go
@@ -77,6 +77,81 @@ func TestFrameCodecDecompressErrors(t *testing.T) {
 	}
 }
 
+// TestFrameCodecDecompressCorruptFrame feeds Decompress compressed frames which
+// are not valid DEFLATE. Those come straight off the network, so they must be
+// reported as an error rather than silently yielding partial output - and since
+// the failed reader goes back to the pool, the codec must keep decoding valid
+// frames afterwards.
+func TestFrameCodecDecompressCorruptFrame(t *testing.T) {
+	dict := []byte(`{"push":{"id":,"pub":{"data":{"offset":`)
+	c := NewDeflateFrameCodec("v1", dict, testCompressionLevel)
+	msg := []byte(`{"push":{"id":7,"pub":{"data":{"price":123.45},"offset":42}}}`)
+	valid := c.Compress(nil, msg)
+	if valid[0] != FrameCodecCompressed {
+		t.Fatalf("expected a compressed frame, got marker %#x", valid[0])
+	}
+
+	corrupt := map[string][]byte{
+		"truncated body": valid[:len(valid)/2],
+		"no body":        {FrameCodecCompressed},
+		// 0xff starts a block of the reserved DEFLATE block type.
+		"reserved block type": {FrameCodecCompressed, 0xff, 0xff, 0xff},
+	}
+	for name, frame := range corrupt {
+		t.Run(name, func(t *testing.T) {
+			out, err := c.Decompress(nil, frame, 1<<20)
+			if err == nil {
+				t.Fatalf("expected an error, got output %q", out)
+			}
+			if out != nil {
+				t.Fatalf("expected no output together with error %v, got %q", err, out)
+			}
+			out, err = c.Decompress(nil, valid, 1<<20)
+			if err != nil || !bytes.Equal(out, msg) {
+				t.Fatalf("codec did not recover after a corrupt frame: err=%v out=%q", err, out)
+			}
+		})
+	}
+}
+
+// TestFrameCodecAppendsToDst checks that Compress and Decompress append to dst
+// rather than overwrite it, for both frame markers, and that maxSize bounds only
+// the decompressed output and not what dst already held.
+func TestFrameCodecAppendsToDst(t *testing.T) {
+	dict := []byte(`{"push":{"id":,"pub":{"data":{"offset":`)
+	c := NewDeflateFrameCodec("v1", dict, testCompressionLevel)
+	prefix := []byte("prefix")
+
+	payloads := map[string][]byte{
+		"compressed": []byte(`{"push":{"id":7,"pub":{"data":{"price":123.45},"offset":42}}}`),
+		"raw":        {0x01, 0x80, 0x7f, 0x13},
+	}
+	for name, msg := range payloads {
+		t.Run(name, func(t *testing.T) {
+			frame := c.Compress(append([]byte(nil), prefix...), msg)
+			if !bytes.HasPrefix(frame, prefix) {
+				t.Fatalf("Compress dropped dst: %q", frame)
+			}
+			frame = frame[len(prefix):]
+			wantMarker := FrameCodecCompressed
+			if name == "raw" {
+				wantMarker = FrameCodecRaw
+			}
+			if frame[0] != wantMarker {
+				t.Fatalf("expected marker %#x, got %#x", wantMarker, frame[0])
+			}
+
+			out, err := c.Decompress(append([]byte(nil), prefix...), frame, len(msg))
+			if err != nil {
+				t.Fatalf("Decompress failed: %v", err)
+			}
+			if want := append(append([]byte(nil), prefix...), msg...); !bytes.Equal(out, want) {
+				t.Fatalf("expected %q, got %q", want, out)
+			}
+		})
+	}
+}
+
 // TestFrameCodecDecompressMaxSizeOverflow guards against int64(maxSize)+1
 // overflowing when maxSize is math.MaxInt: that used to turn into a negative
 // io.LimitReader budget, which made Decompress return an empty result with no
@@ -138,6 +213,26 @@ func TestInflateDictionaryTooLarge(t *testing.T) {
 	compressed := DeflateDictionary(dict, testCompressionLevel)
 	if _, err := InflateDictionary(compressed, len(dict)-1); err == nil {
 		t.Fatal("expected an error when inflated dictionary exceeds maxSize")
+	}
+}
+
+// TestInflateDictionaryCorrupt checks that dictionary content which is not
+// valid DEFLATE is rejected rather than installed truncated or empty.
+func TestInflateDictionaryCorrupt(t *testing.T) {
+	dict := bytes.Repeat([]byte(`{"push":{"id":3,"pub":{"data":{}}}}`), 50)
+	compressed := DeflateDictionary(dict, testCompressionLevel)
+
+	corrupt := map[string][]byte{
+		"truncated":           compressed[:len(compressed)/2],
+		"empty":               {},
+		"reserved block type": {0xff, 0xff, 0xff},
+	}
+	for name, data := range corrupt {
+		t.Run(name, func(t *testing.T) {
+			if out, err := InflateDictionary(data, len(dict)); err == nil {
+				t.Fatalf("expected an error, got %d B of output", len(out))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Adds three tests to `framecodec_test.go`. No production code changes.

- `TestFrameCodecDecompressCorruptFrame`: `Decompress` gets a `FrameCodecCompressed` frame that isn't valid DEFLATE, in three forms: the body cut in half, a marker with no body, and a body starting with the reserved DEFLATE block type. Each must return an error with nil output. After each failure the same codec must still decode a valid frame. This matters because the failed `flate` reader goes back into the codec's `sync.Pool` and gets reused.
- `TestInflateDictionaryCorrupt`: `InflateDictionary` gets truncated, empty and reserved-block-type input. It must return an error, not an empty or partial dictionary.
- `TestFrameCodecAppendsToDst`: `Compress` and `Decompress` must append to a non-empty `dst`, not overwrite it. This is checked for both the compressed and the raw-fallback marker. With `maxSize` set to exactly the payload length, it also checks that the limit counts only decompressed bytes, not what `dst` already held.

## Why

`Decompress` and `InflateDictionary` decode bytes that come from the other side of a connection. Until now no test gave them invalid compressed data: the `ReadFrom` error branch in `Decompress` and the `io.ReadAll` error branch in `InflateDictionary` were never run, and nothing fuzzes these functions. Existing tests also always passed `nil` as `dst`, so appending to a non-empty `dst`, which is the reason the parameter exists, wasn't checked.

No bugs turned up. All the new assertions pass against the current code. With these tests, `InflateDictionary` coverage goes to 100% and `Decompress` to 94.7%. The lines still uncovered can't be reached: a `bytes.Reader` never makes `Reset` fail, and `DeflateDictionary` only writes to a `bytes.Buffer`.

## Verification

- `go test -race -count=1 .`: passes
- `go vet .`: no findings outside the generated easyjson file (those warnings were already there)
- `gofmt -l framecodec_test.go`: clean