### PR TITLE
Add tests for ProtobufCommandDecoder on malformed frames

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -156,6 +156,63 @@ func TestProtobufCommandDecoder_Decode_ShortData(t *testing.T) {
 	}
 }
 
+// Commands come from an untrusted client, so malformed input must produce an
+// error without a Command - decoding must never panic and must always terminate.
+func TestProtobufCommandDecoder_Decode_Malformed(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		err  error
+	}{
+		{
+			name: "empty frame",
+			data: []byte{},
+			err:  io.EOF,
+		},
+		{
+			name: "length prefix beyond buffer",
+			data: []byte{0x10, 0x01, 0x02},
+			err:  io.ErrShortBuffer,
+		},
+		{
+			name: "truncated varint",
+			data: []byte{0x80},
+			err:  io.EOF,
+		},
+		{
+			name: "varint overflowing uint64",
+			data: []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02},
+			err:  io.EOF,
+		},
+		{
+			name: "length overflowing int arithmetic",
+			data: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f, 0x01},
+			err:  io.ErrShortBuffer,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoder := NewProtobufCommandDecoder(tt.data)
+			cmd, err := decoder.Decode()
+			require.Nil(t, cmd)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+// A body which fails to unmarshal must be reported as an error of its own - not
+// as io.EOF, which callers treat as a fully processed frame.
+func TestProtobufCommandDecoder_Decode_InvalidBody(t *testing.T) {
+	badBody := []byte{0x0F} // Field 1 with wire type 7, which is not valid.
+	data := append([]byte{byte(len(badBody))}, badBody...)
+
+	decoder := NewProtobufCommandDecoder(data)
+	cmd, err := decoder.Decode()
+	require.Nil(t, cmd)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, io.EOF)
+}
+
 func readReplies(t testing.TB, decoder ReplyDecoder) []*Reply {
 	t.Helper()
 	var replies []*Reply


### PR DESCRIPTION
## What

Adds two tests to `decode_test.go` for `ProtobufCommandDecoder.Decode`:

- `TestProtobufCommandDecoder_Decode_Malformed`: a table test checking that each malformed frame returns a nil `Command` and the expected error:
  - empty frame: `io.EOF`
  - length prefix pointing past the end of the buffer: `io.ErrShortBuffer`
  - truncated varint: `io.EOF`
  - varint that overflows uint64: `io.EOF`
  - length that overflows the `offset + n + int(l)` arithmetic: `io.ErrShortBuffer` (the `from <= to` guard)
- `TestProtobufCommandDecoder_Decode_InvalidBody`: a correctly framed body that fails `UnmarshalVT` returns a nil `Command` and an error that is **not** `io.EOF`. Callers treat `io.EOF` as "frame fully processed", so a bad body must not be reported that way.

## Why

`ProtobufCommandDecoder` is the server-side decoder for frames that clients send, so its input is untrusted. Until now only the happy path and a short buffer were tested. `ProtobufReplyDecoder` already has the same kind of malformed-input table (`TestProtobufReplyDecoder_Decode_Malformed`); these tests follow that pattern for the command side. They pin down the current behaviour, including the overflow guard, so a later refactor of `Decode` can't quietly change it.

Only tests are added; no production code changes. Coverage of `ProtobufCommandDecoder.Decode` goes from 83.3% to 100%.

## Verification

- `go test -race -count=1 ./...` passes
- `golangci-lint run --timeout 3m0s` reports 0 issues
- `gofmt -l` is clean